### PR TITLE
[feat] JWT 2, 3단계 개발

### DIFF
--- a/src/main/java/com/piveguyz/empickbackend/auth/command/application/controller/AuthCommandController.java
+++ b/src/main/java/com/piveguyz/empickbackend/auth/command/application/controller/AuthCommandController.java
@@ -24,7 +24,12 @@ public class AuthCommandController {
 
     @Operation(
             summary = "로그인",
-            description = "사번과 비밀번호를 통해 로그인을 수행하고 AccessToken 및 RefreshToken을 발급합니다."
+            description = """
+                    - 사번과 비밀번호를 통해 로그인을 수행하고 AccessToken 및 RefreshToken을 발급합니다.
+                    더미 회원 정보
+                    - employeeNumber : 100001, pwd :  password1234@@
+                    - employeeNumber : 100002, pwd :  password5678@@
+                    """
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "로그인 성공",
@@ -33,6 +38,7 @@ public class AuthCommandController {
             @ApiResponse(responseCode = "401", description = "인증 실패"),
             @ApiResponse(responseCode = "500", description = "서버 오류")
     })
+
     @PostMapping("/login")
     public ResponseEntity<LoginResponseDTO> login(@Valid @RequestBody LoginRequestDTO requestDTO) {
         LoginResponseDTO responseDTO = authCommandService.login(requestDTO);

--- a/src/main/java/com/piveguyz/empickbackend/auth/command/application/controller/AuthCommandController.java
+++ b/src/main/java/com/piveguyz/empickbackend/auth/command/application/controller/AuthCommandController.java
@@ -1,0 +1,41 @@
+package com.piveguyz.empickbackend.auth.command.application.controller;
+
+import com.piveguyz.empickbackend.auth.command.application.dto.LoginRequestDTO;
+import com.piveguyz.empickbackend.auth.command.application.dto.LoginResponseDTO;
+import com.piveguyz.empickbackend.auth.command.application.service.AuthCommandService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+@Tag(name = "인증 API", description = "로그인/회원가입/토큰 발급 등 인증 관련 API")
+public class AuthCommandController {
+
+    private final AuthCommandService authCommandService;
+
+    @Operation(
+            summary = "로그인",
+            description = "사번과 비밀번호를 통해 로그인을 수행하고 AccessToken 및 RefreshToken을 발급합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "로그인 성공",
+                    content = @Content(schema = @Schema(implementation = LoginResponseDTO.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponseDTO> login(@Valid @RequestBody LoginRequestDTO requestDTO) {
+        LoginResponseDTO responseDTO = authCommandService.login(requestDTO);
+        return ResponseEntity.ok(responseDTO);
+    }
+}

--- a/src/main/java/com/piveguyz/empickbackend/auth/command/application/controller/AuthCommandController.java
+++ b/src/main/java/com/piveguyz/empickbackend/auth/command/application/controller/AuthCommandController.java
@@ -15,7 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/auth")
+@RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
 @Tag(name = "인증 API", description = "로그인/회원가입/토큰 발급 등 인증 관련 API")
 public class AuthCommandController {

--- a/src/main/java/com/piveguyz/empickbackend/auth/command/application/dto/LoginRequestDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/auth/command/application/dto/LoginRequestDTO.java
@@ -1,0 +1,21 @@
+package com.piveguyz.empickbackend.auth.command.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LoginRequestDTO {
+
+    @NotBlank(message = "사번은 필수 입력값입니다.")
+    private String employeeNumber;
+
+    @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+    private String password;
+
+}

--- a/src/main/java/com/piveguyz/empickbackend/auth/command/application/dto/LoginResponseDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/auth/command/application/dto/LoginResponseDTO.java
@@ -3,10 +3,12 @@ package com.piveguyz.empickbackend.auth.command.application.dto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
 @Builder
+@NoArgsConstructor(force = true)
 public class LoginResponseDTO {
     private final String accessToken;
     private final String refreshToken;

--- a/src/main/java/com/piveguyz/empickbackend/auth/command/application/dto/LoginResponseDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/auth/command/application/dto/LoginResponseDTO.java
@@ -1,0 +1,13 @@
+package com.piveguyz.empickbackend.auth.command.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class LoginResponseDTO {
+    private final String accessToken;
+    private final String refreshToken;
+}

--- a/src/main/java/com/piveguyz/empickbackend/auth/command/application/service/AuthCommandService.java
+++ b/src/main/java/com/piveguyz/empickbackend/auth/command/application/service/AuthCommandService.java
@@ -1,0 +1,8 @@
+package com.piveguyz.empickbackend.auth.command.application.service;
+
+import com.piveguyz.empickbackend.auth.command.application.dto.LoginRequestDTO;
+import com.piveguyz.empickbackend.auth.command.application.dto.LoginResponseDTO;
+
+public interface AuthCommandService {
+    LoginResponseDTO login(LoginRequestDTO requestDTO);
+}

--- a/src/main/java/com/piveguyz/empickbackend/auth/command/application/service/AuthCommandServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/auth/command/application/service/AuthCommandServiceImpl.java
@@ -1,0 +1,40 @@
+package com.piveguyz.empickbackend.auth.command.application.service;
+
+import com.piveguyz.empickbackend.auth.command.application.dto.LoginRequestDTO;
+import com.piveguyz.empickbackend.auth.command.application.dto.LoginResponseDTO;
+import com.piveguyz.empickbackend.auth.command.jwt.JwtProvider;
+import com.piveguyz.empickbackend.member.command.domain.aggregate.Member;
+import com.piveguyz.empickbackend.member.command.domain.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthCommandServiceImpl implements AuthCommandService {
+
+    private final MemberRepository memberRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public LoginResponseDTO login(LoginRequestDTO requestDTO) {
+        Member member = memberRepository.findByEmployeeNumber(
+                Integer.parseInt(
+                        requestDTO.getEmployeeNumber()
+                )
+        ).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+        if (!passwordEncoder.matches(requestDTO.getPassword(), member.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        String accessToken = jwtProvider.createAccessToken(member.getId(), member.getEmployeeNumber());
+        String refreshToken = jwtProvider.createRefreshToken(member.getId(), member.getEmployeeNumber());
+
+        return LoginResponseDTO.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/com/piveguyz/empickbackend/auth/command/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/piveguyz/empickbackend/auth/command/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,56 @@
+package com.piveguyz.empickbackend.auth.command.jwt;
+
+import com.piveguyz.empickbackend.security.CustomMemberDetails;
+import com.piveguyz.empickbackend.security.CustomMemberDetailsService;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+    private final CustomMemberDetailsService customMemberDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String token = authHeader.substring(7);
+            try {
+                Claims claims = jwtProvider.parseClaims(token);
+                String memberId = claims.getSubject();
+
+                // memberId로 사용자 정보 조회
+                CustomMemberDetails memberDetails =
+                        (CustomMemberDetails) customMemberDetailsService.loadUserByUsername(memberId);
+
+                // SecurityContextHolder에 인증 객체 주입
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(memberDetails, null, memberDetails.getAuthorities());
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            } catch (JwtException e) {
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid or expired token");
+                return;
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/piveguyz/empickbackend/auth/command/jwt/JwtProvider.java
+++ b/src/main/java/com/piveguyz/empickbackend/auth/command/jwt/JwtProvider.java
@@ -1,0 +1,46 @@
+package com.piveguyz.empickbackend.auth.command.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtProvider {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    private Key key;
+    private final long accessTokenValidity = 1000 * 60 * 60; // 1시간
+    private final long refreshTokenValidity = 1000 * 60 * 60 * 24 * 7; // 1주일
+
+    @PostConstruct
+    public void init() {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes());
+    }
+
+    public String createAccessToken(int memberId, Integer employeeNumber) {
+        return Jwts.builder()
+                .setSubject(String.valueOf(memberId))
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + accessTokenValidity))
+                .claim("employeeNumber", employeeNumber)
+                .signWith(key)
+                .compact();
+    }
+
+    public String createRefreshToken(int memberId, Integer employeeNumber) {
+        return Jwts.builder()
+                .setSubject(String.valueOf(employeeNumber))
+                .claim("memberId", memberId)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + refreshTokenValidity))
+                .signWith(key)
+                .compact();
+    }
+}

--- a/src/main/java/com/piveguyz/empickbackend/auth/command/jwt/JwtProvider.java
+++ b/src/main/java/com/piveguyz/empickbackend/auth/command/jwt/JwtProvider.java
@@ -1,5 +1,6 @@
 package com.piveguyz.empickbackend.auth.command.jwt;
 
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
@@ -42,5 +43,13 @@ public class JwtProvider {
                 .setExpiration(new Date(System.currentTimeMillis() + refreshTokenValidity))
                 .signWith(key)
                 .compact();
+    }
+
+    public Claims parseClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
     }
 }

--- a/src/main/java/com/piveguyz/empickbackend/common/config/OpenApiConfig.java
+++ b/src/main/java/com/piveguyz/empickbackend/common/config/OpenApiConfig.java
@@ -1,0 +1,23 @@
+package com.piveguyz.empickbackend.common.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import org.springframework.context.annotation.Configuration;
+
+@OpenAPIDefinition(
+        info = @Info(title = "Empick API", version = "v1"),
+        security = @SecurityRequirement(name = "bearerAuth")
+)
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT"
+)
+
+@Configuration
+public class OpenApiConfig {
+}

--- a/src/main/java/com/piveguyz/empickbackend/common/config/SecurityConfig.java
+++ b/src/main/java/com/piveguyz/empickbackend/common/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.piveguyz.empickbackend.common.config;
 
+import com.piveguyz.empickbackend.auth.command.jwt.JwtAuthenticationFilter;
 import com.piveguyz.empickbackend.security.CustomMemberDetailsService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -10,6 +11,7 @@ import org.springframework.security.config.annotation.authentication.configurati
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -35,11 +37,12 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain filterChain(HttpSecurity http, JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
         http
                 .cors(Customizer.withDefaults()) // CORS 적용
-                .csrf(csrf -> csrf.disable())   // 개발 환경에서 CSRF 끄기
+                .csrf(csrf -> csrf.disable())    // CSRF 끄기
                 .authorizeHttpRequests(auth -> auth
+                        // ✅ 인증이 필요 없는 경로
                         .requestMatchers(
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**",
@@ -47,12 +50,20 @@ public class SecurityConfig {
                                 "/swagger-resources/**",
                                 "/webjars/**"
                         ).permitAll()
-                        .requestMatchers("/api/**").permitAll()
-                        .anyRequest().authenticated()
-                );
+                        // ⬇️ 아래 두 줄 중 상황에 맞게 선택 (개발/배포)
+
+                        // ✅ 인증이 필요 없는 로그인/회원가입 경로 (배포 시 주석 해제 X, 개발 시 주석 해제 O)
+                        .requestMatchers("/api/auth/**").permitAll()
+                        // 🔒 인증이 필요한 나머지 API 경로 (배포 시 주석 해제 O, 개발 시 주석처리 O)
+//                        .requestMatchers("/api/**").authenticated()
+                )
+                // JWT 인증 필터 추가
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
+
+
 
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {

--- a/src/main/java/com/piveguyz/empickbackend/common/config/SecurityConfig.java
+++ b/src/main/java/com/piveguyz/empickbackend/common/config/SecurityConfig.java
@@ -50,20 +50,18 @@ public class SecurityConfig {
                                 "/swagger-resources/**",
                                 "/webjars/**"
                         ).permitAll()
-                        // ⬇️ 아래 두 줄 중 상황에 맞게 선택 (개발/배포)
-
-                        // ✅ 인증이 필요 없는 로그인/회원가입 경로 (배포 시 주석 해제 X, 개발 시 주석 해제 O)
-                        .requestMatchers("/api/auth/**").permitAll()
-                        // 🔒 인증이 필요한 나머지 API 경로 (배포 시 주석 해제 O, 개발 시 주석처리 O)
-//                        .requestMatchers("/api/**").authenticated()
+                        // ✅ 로그인/회원가입 경로는 인증 필요 없음
+                        .requestMatchers("/api/v1/auth/**").permitAll()
+                        // 🔒 그 외 모든 /api/** 경로는 JWT 인증 필터 작동
+                        .requestMatchers("/api/**").authenticated()
+                        // 🔒 나머지 경로는 기본 인증
+                        .anyRequest().authenticated()
                 )
                 // JWT 인증 필터 추가
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
-
-
 
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {

--- a/src/main/java/com/piveguyz/empickbackend/common/util/JwtSecretGenerator.java
+++ b/src/main/java/com/piveguyz/empickbackend/common/util/JwtSecretGenerator.java
@@ -1,0 +1,15 @@
+package com.piveguyz.empickbackend.common.util;
+
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import java.util.Base64;
+
+public class JwtSecretGenerator {
+    public static void main(String[] args) throws Exception {
+        KeyGenerator keyGen = KeyGenerator.getInstance("HmacSHA256");
+        keyGen.init(256); // 256-bit key
+        SecretKey secretKey = keyGen.generateKey();
+        String encodedKey = Base64.getEncoder().encodeToString(secretKey.getEncoded());
+        System.out.println("Generated JWT Secret Key: " + encodedKey);
+    }
+}

--- a/src/main/java/com/piveguyz/empickbackend/common/util/PasswordEncoder.java
+++ b/src/main/java/com/piveguyz/empickbackend/common/util/PasswordEncoder.java
@@ -5,7 +5,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 public class PasswordEncoder {
     public static void main(String[] args) {
         BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
-        String rawPassword = "password5678@@";
+        String rawPassword = "password1234@@";
         String encodedPassword = encoder.encode(rawPassword);
         System.out.println("BCrypt 암호화된 비밀번호: " + encodedPassword);
     }

--- a/src/main/java/com/piveguyz/empickbackend/common/util/PasswordEncoder.java
+++ b/src/main/java/com/piveguyz/empickbackend/common/util/PasswordEncoder.java
@@ -1,0 +1,12 @@
+package com.piveguyz.empickbackend.common.util;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+public class PasswordEncoder {
+    public static void main(String[] args) {
+        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+        String rawPassword = "password5678@@";
+        String encodedPassword = encoder.encode(rawPassword);
+        System.out.println("BCrypt 암호화된 비밀번호: " + encodedPassword);
+    }
+}

--- a/src/main/java/com/piveguyz/empickbackend/member/command/domain/aggregate/Member.java
+++ b/src/main/java/com/piveguyz/empickbackend/member/command/domain/aggregate/Member.java
@@ -22,7 +22,7 @@ public class Member {
     private String password;
 
     @Column(name = "employee_number", nullable = false)
-    private int employeeNumber;
+    private Integer employeeNumber;
 
     @Column(name = "name", nullable = false, length = 255)
     private String name;

--- a/src/main/java/com/piveguyz/empickbackend/member/query/controller/MemberQueryController.java
+++ b/src/main/java/com/piveguyz/empickbackend/member/query/controller/MemberQueryController.java
@@ -1,0 +1,36 @@
+package com.piveguyz.empickbackend.member.query.controller;
+
+import com.piveguyz.empickbackend.member.query.dto.MemberResponseDTO;
+import com.piveguyz.empickbackend.member.query.service.MemberQueryService;
+import com.piveguyz.empickbackend.security.CustomMemberDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "회원 API", description = "회원 정보 조회 API")
+@RestController
+@RequestMapping("/api/v1/member")
+@RequiredArgsConstructor
+public class MemberQueryController {
+
+    private final MemberQueryService memberQueryService;
+
+    @Operation(summary = "내 정보 조회", description = "로그인한 사용자의 정보를 조회합니다. (JWT 토큰 필요)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원 정보 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패 (JWT 토큰 필요)"),
+            @ApiResponse(responseCode = "404", description = "회원 정보를 찾을 수 없음")
+    })
+    @GetMapping("/me")
+    public ResponseEntity<MemberResponseDTO> getCurrentMember(@AuthenticationPrincipal CustomMemberDetails memberDetails) {
+        MemberResponseDTO dto = memberQueryService.getMemberInfo(memberDetails.getMember().getId());
+        return ResponseEntity.ok(dto);
+    }
+}

--- a/src/main/java/com/piveguyz/empickbackend/member/query/dto/MemberResponseDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/member/query/dto/MemberResponseDTO.java
@@ -1,0 +1,13 @@
+package com.piveguyz.empickbackend.member.query.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberResponseDTO {
+    private int id;
+    private String name;
+    private int employeeNumber;
+    private String email;
+}

--- a/src/main/java/com/piveguyz/empickbackend/member/query/service/MemberQueryService.java
+++ b/src/main/java/com/piveguyz/empickbackend/member/query/service/MemberQueryService.java
@@ -1,0 +1,7 @@
+package com.piveguyz.empickbackend.member.query.service;
+
+import com.piveguyz.empickbackend.member.query.dto.MemberResponseDTO;
+
+public interface MemberQueryService {
+    MemberResponseDTO getMemberInfo(int memberId);
+}

--- a/src/main/java/com/piveguyz/empickbackend/member/query/service/MemberQueryServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/member/query/service/MemberQueryServiceImpl.java
@@ -1,0 +1,27 @@
+package com.piveguyz.empickbackend.member.query.service;
+
+import com.piveguyz.empickbackend.member.command.domain.aggregate.Member;
+import com.piveguyz.empickbackend.member.command.domain.repository.MemberRepository;
+import com.piveguyz.empickbackend.member.query.dto.MemberResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberQueryServiceImpl implements MemberQueryService{
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public MemberResponseDTO getMemberInfo(int memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("회원 정보를 찾을 수 없습니다."));
+
+        return new MemberResponseDTO(
+                member.getId(),
+                member.getName(),
+                member.getEmployeeNumber(),
+                member.getEmail()
+        );
+    }
+}

--- a/src/main/java/com/piveguyz/empickbackend/security/CustomMemberDetailsService.java
+++ b/src/main/java/com/piveguyz/empickbackend/security/CustomMemberDetailsService.java
@@ -20,16 +20,17 @@ public class CustomMemberDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        int empNum;
+        int memberId;
         try {
-            empNum = Integer.parseInt(username);
+            memberId = Integer.parseInt(username);
         } catch (NumberFormatException e) {
-            throw new UsernameNotFoundException("유효하지 않은 사번입니다: " + username);
+            throw new UsernameNotFoundException("유효하지 않은 사원 ID입니다: " + username);
         }
 
-        Member member = memberRepository.findByEmployeeNumber(empNum)
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new UsernameNotFoundException("사원이 존재하지 않습니다."));
 
         return new CustomMemberDetails(member);
     }
+
 }


### PR DESCRIPTION
### 🪄 PR 타입
- [x] 신규 기능
- [ ] 기능 수정
- [x] 리팩토링
- [ ] 버그 픽스

### 📝 변경 사항

- 비밀번호와 secret key 생성 util 구현
- 사번 타입을 Integer로 변경
- JwtProvider 구현
- 로그인 api 구현 (accessToken, refreshToken 발급)
- 토큰 인증 구현

### #️⃣ 연관된 이슈
close #25 
close #31  

### 📷 관련 스크린샷

로그인
<img width="1300" alt="image" src="https://github.com/user-attachments/assets/04cff14c-c805-47d7-9a70-1bdfa3e8c223" />

토큰 인증 (스웨거에선 작동하지 않음)
<img width="697" alt="스크린샷 2025-06-02 19 15 08" src="https://github.com/user-attachments/assets/a094b0c6-aa34-4781-919f-5c5ee6e0eded" />



### 🧪 테스트 계획 또는 완료 사항
- [ ] [스웨거-인증API](http://localhost:5001/swagger-ui/index.html)

curl -X GET \
  http://localhost:5001/api/v1/member/me \                      
  -H "Authorization: Bearer 발급받은토큰입력"

