### PR TITLE
[feat] custom api response HttpStatus도 함께 저장

### DIFF
--- a/src/main/java/com/piveguyz/empickbackend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/piveguyz/empickbackend/common/exception/GlobalExceptionHandler.java
@@ -47,7 +47,7 @@ public class GlobalExceptionHandler {
     }
 
     /**
-     * Enum 파싱 실패 처리 (type, difficulty)
+     * Enum 파싱 실패 처리
      */
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<CustomApiResponse<Void>> handleHttpMessageNotReadable(HttpMessageNotReadableException ex) {

--- a/src/main/java/com/piveguyz/empickbackend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/piveguyz/empickbackend/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.piveguyz.empickbackend.common.exception;
 
-import com.piveguyz.empickbackend.common.response.ApiResponse;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.piveguyz.empickbackend.common.response.CustomApiResponse;
 import com.piveguyz.empickbackend.common.response.ResponseCode;
 import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.validation.ConstraintViolationException;
@@ -20,38 +21,51 @@ public class GlobalExceptionHandler {
      *  ApiResponse 기반 커스텀 예외 핸들러
      */
     @ExceptionHandler(BusinessException.class)
-    public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException ex) {
+    public ResponseEntity<CustomApiResponse<Void>> handleBusinessException(BusinessException ex) {
         return ResponseEntity
                 .status(HttpStatus.valueOf(ex.getCode().getCode()))
-                .body(ApiResponse.of(ex.getCode()));
+                .body(CustomApiResponse.of(ex.getCode()));
     }
 
     /**
      * @Valid 유효성 검증 실패 처리
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse<String>> handleValidationException(MethodArgumentNotValidException ex) {
+    public ResponseEntity<CustomApiResponse<String>> handleValidationException(MethodArgumentNotValidException ex) {
         String errorMessage = Objects.requireNonNull(ex.getBindingResult().getFieldError()).getDefaultMessage();
         return ResponseEntity.badRequest()
-                .body(ApiResponse.of(ResponseCode.VALIDATION_FAIL, errorMessage));
+                .body(CustomApiResponse.of(ResponseCode.VALIDATION_FAIL, errorMessage));
     }
 
     /**
      * @Validated 유효성 검증 실패 처리 (예: @RequestParam)
      */
     @ExceptionHandler(ConstraintViolationException.class)
-    public ResponseEntity<ApiResponse<String>> handleConstraintViolation(ConstraintViolationException ex) {
+    public ResponseEntity<CustomApiResponse<String>> handleConstraintViolation(ConstraintViolationException ex) {
         return ResponseEntity.badRequest()
-                .body(ApiResponse.of(ResponseCode.VALIDATION_FAIL, ex.getMessage()));
+                .body(CustomApiResponse.of(ResponseCode.VALIDATION_FAIL, ex.getMessage()));
+    }
+
+    /**
+     * Enum 유효성 검사
+     */
+    @ExceptionHandler(InvalidFormatException.class)
+    public ResponseEntity<CustomApiResponse<Void>> handleInvalidFormat(InvalidFormatException ex) {
+        if (ex.getPathReference().contains("type")) {
+            return ResponseEntity.badRequest().body(CustomApiResponse.of(ResponseCode.EMPLOYMENT_INVALID_TYPE));
+        } else if (ex.getPathReference().contains("difficulty")) {
+            return ResponseEntity.badRequest().body(CustomApiResponse.of(ResponseCode.EMPLOYMENT_INVALID_DIFFICULTY));
+        }
+        return ResponseEntity.badRequest().body(CustomApiResponse.of(ResponseCode.BAD_REQUEST));
     }
 
     /**
      * 그 외 모든 예외 처리 (예기치 않은 에러)
      */
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<Void>> handleException(Exception ex) {
+    public ResponseEntity<CustomApiResponse<Void>> handleException(Exception ex) {
         ex.printStackTrace(); // 로그로 남기기
         return ResponseEntity.internalServerError()
-                .body(ApiResponse.of(ResponseCode.INTERNAL_SERVER_ERROR));
+                .body(CustomApiResponse.of(ResponseCode.INTERNAL_SERVER_ERROR));
     }
 }

--- a/src/main/java/com/piveguyz/empickbackend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/piveguyz/empickbackend/common/exception/GlobalExceptionHandler.java
@@ -47,6 +47,20 @@ public class GlobalExceptionHandler {
     }
 
     /**
+     * Enum 유효성 검사
+     */
+    @ExceptionHandler(InvalidFormatException.class)
+    public ResponseEntity<CustomApiResponse<Void>> handleInvalidFormat(InvalidFormatException ex) {
+        String field = ex.getPath().get(0).getFieldName();
+        if ("type".equals(field)) {
+            return ResponseEntity.badRequest().body(CustomApiResponse.of(ResponseCode.EMPLOYMENT_INVALID_TYPE));
+        } else if ("difficulty".equals(field)) {
+            return ResponseEntity.badRequest().body(CustomApiResponse.of(ResponseCode.EMPLOYMENT_INVALID_DIFFICULTY));
+        }
+        return ResponseEntity.badRequest().body(CustomApiResponse.of(ResponseCode.BAD_REQUEST));
+    }
+
+    /**
      * 그 외 모든 예외 처리 (예기치 않은 에러)
      */
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/piveguyz/empickbackend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/piveguyz/empickbackend/common/exception/GlobalExceptionHandler.java
@@ -23,7 +23,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<CustomApiResponse<Void>> handleBusinessException(BusinessException ex) {
         return ResponseEntity
-                .status(HttpStatus.valueOf(ex.getCode().getCode()))
+                .status(ex.getCode().getHttpStatus())
                 .body(CustomApiResponse.of(ex.getCode()));
     }
 
@@ -52,12 +52,20 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(InvalidFormatException.class)
     public ResponseEntity<CustomApiResponse<Void>> handleInvalidFormat(InvalidFormatException ex) {
         String field = ex.getPath().get(0).getFieldName();
+
         if ("type".equals(field)) {
-            return ResponseEntity.badRequest().body(CustomApiResponse.of(ResponseCode.EMPLOYMENT_INVALID_TYPE));
+            return ResponseEntity
+                    .status(ResponseCode.EMPLOYMENT_QUESTION_INVALID_TYPE.getHttpStatus())
+                    .body(CustomApiResponse.of(ResponseCode.EMPLOYMENT_QUESTION_INVALID_TYPE));
         } else if ("difficulty".equals(field)) {
-            return ResponseEntity.badRequest().body(CustomApiResponse.of(ResponseCode.EMPLOYMENT_INVALID_DIFFICULTY));
+            return ResponseEntity
+                    .status(ResponseCode.EMPLOYMENT_QUESTION_INVALID_DIFFICULTY.getHttpStatus())
+                    .body(CustomApiResponse.of(ResponseCode.EMPLOYMENT_QUESTION_INVALID_DIFFICULTY));
         }
-        return ResponseEntity.badRequest().body(CustomApiResponse.of(ResponseCode.BAD_REQUEST));
+
+        return ResponseEntity
+                .status(ResponseCode.BAD_REQUEST.getHttpStatus())
+                .body(CustomApiResponse.of(ResponseCode.BAD_REQUEST));
     }
 
     /**

--- a/src/main/java/com/piveguyz/empickbackend/common/response/ResponseCode.java
+++ b/src/main/java/com/piveguyz/empickbackend/common/response/ResponseCode.java
@@ -63,18 +63,4 @@ public enum ResponseCode {
     private final HttpStatus httpStatus;        // HTTP 상태 코드
     private final int code;                     // 비지니스 로직
     private final String message;
-
-    public boolean isSuccess() {
-        return success;
-    }
-
-    public int getCode() {
-        return code;
-    }
-
-    public String getMessage() {
-        return message;
-    }
-
-    public HttpStatus getHttpStatus() { return httpStatus; }
 }

--- a/src/main/java/com/piveguyz/empickbackend/common/response/ResponseCode.java
+++ b/src/main/java/com/piveguyz/empickbackend/common/response/ResponseCode.java
@@ -36,9 +36,14 @@ public enum ResponseCode {
 
 
     //  실무테스트 - 2400 ~ 2499
-    EMPLOYMENT_QUESTION_FAIL(false, 2400, "실무테스트 문제 등록에 실패했습니다."),
-    EMPLOYMENT_QUESTION_DUPLICATE(false, 2401, "동일한 문제가 이미 등록되어 있습니다"),
-    EMPLOYMENT_QUESTION_NOT_FOUND(false, 2402, "요청한 문제를 찾을 수 없습니다.");
+    EMPLOYMENT_INVALID_DIFFICULTY(false, 2400, "유효하지 않은 난이도입니다."),
+    EMPLOYMENT_INVALID_TYPE(false, 2401, "유효하지 않은 실무 테스트 유형입니다."),
+
+    //   1) 실무테스트 문제
+    EMPLOYMENT_QUESTION_FAIL(false, 2410, "실무테스트 문제 등록에 실패했습니다."),
+    EMPLOYMENT_QUESTION_DUPLICATE(false, 2411, "동일한 문제가 이미 등록되어 있습니다."),
+    EMPLOYMENT_QUESTION_INVALID_MEMBER(false, 2412, "작성자가 존재하지 않습니다."),
+    EMPLOYMENT_QUESTION_NOT_FOUND(false, 2413, "요청한 문제를 찾을 수 없습니다.");
 
     //  면접 일정 - 2500 ~ 2599
 

--- a/src/main/java/com/piveguyz/empickbackend/common/response/ResponseCode.java
+++ b/src/main/java/com/piveguyz/empickbackend/common/response/ResponseCode.java
@@ -1,23 +1,29 @@
 package com.piveguyz.empickbackend.common.response;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
 /**
  * 성공/에러 메세지 코드 관리
  */
 
+@Getter
+@RequiredArgsConstructor
 public enum ResponseCode {
 
     // 모든 성공 코드
-    SUCCESS(true, 200, "요청이 성공적으로 처리되었습니다."),
+    SUCCESS(true, HttpStatus.OK, 200, "요청이 성공적으로 처리되었습니다."),
 
     // 클라이언트 오류 (4xx)
-    BAD_REQUEST(false, 400, "잘못된 요청입니다."),
-    UNAUTHORIZED(false, 401, "인증이 필요합니다."),
-    FORBIDDEN(false, 403, "접근 권한이 없습니다."),
-    NOT_FOUND(false, 404, "요청한 리소스를 찾을 수 없습니다."),
-    VALIDATION_FAIL(false, 405, "유효성 검증에 실패했습니다."),
+    BAD_REQUEST(false, HttpStatus.BAD_REQUEST, 400, "잘못된 요청입니다."),
+    UNAUTHORIZED(false, HttpStatus.UNAUTHORIZED, 401, "인증이 필요합니다."),
+    FORBIDDEN(false, HttpStatus.FORBIDDEN, 403, "접근 권한이 없습니다."),
+    NOT_FOUND(false, HttpStatus.NOT_FOUND, 404, "요청한 리소스를 찾을 수 없습니다."),
+    VALIDATION_FAIL(false, HttpStatus.BAD_REQUEST, 405, "유효성 검증에 실패했습니다."),
 
     // 서버 오류 (5xx)
-    INTERNAL_SERVER_ERROR(false, 500, "서버 내부 오류입니다."),
+    INTERNAL_SERVER_ERROR(false, HttpStatus.INTERNAL_SERVER_ERROR, 500, "서버 내부 오류입니다."),
 
     // 인사 오류 - 1000 ~ 1999
 
@@ -36,14 +42,16 @@ public enum ResponseCode {
 
 
     //  실무테스트 - 2400 ~ 2499
-    EMPLOYMENT_INVALID_DIFFICULTY(false, 2400, "유효하지 않은 난이도입니다."),
-    EMPLOYMENT_INVALID_TYPE(false, 2401, "유효하지 않은 실무 테스트 유형입니다."),
+    EMPLOYMENT_INVALID_DIFFICULTY(false, HttpStatus.INTERNAL_SERVER_ERROR, 2400, "유효하지 않은 난이도입니다."),
+    EMPLOYMENT_INVALID_TYPE(false, HttpStatus.INTERNAL_SERVER_ERROR, 2401, "유효하지 않은 실무 테스트 유형입니다."),
 
     //   1) 실무테스트 문제
-    EMPLOYMENT_QUESTION_FAIL(false, 2410, "실무테스트 문제 등록에 실패했습니다."),
-    EMPLOYMENT_QUESTION_DUPLICATE(false, 2411, "동일한 문제가 이미 등록되어 있습니다."),
-    EMPLOYMENT_QUESTION_INVALID_MEMBER(false, 2412, "작성자가 존재하지 않습니다."),
-    EMPLOYMENT_QUESTION_NOT_FOUND(false, 2413, "요청한 문제를 찾을 수 없습니다.");
+    EMPLOYMENT_QUESTION_FAIL(false, HttpStatus.INTERNAL_SERVER_ERROR, 2410, "실무테스트 문제 등록에 실패했습니다."),
+    EMPLOYMENT_QUESTION_DUPLICATE(false, HttpStatus.CONFLICT, 2411, "동일한 문제가 이미 등록되어 있습니다."),
+    EMPLOYMENT_QUESTION_NOT_FOUND(false, HttpStatus.NOT_FOUND, 2412, "요청한 문제를 찾을 수 없습니다."),
+    EMPLOYMENT_QUESTION_INVALID_TYPE(false, HttpStatus.BAD_REQUEST, 2413, "유효하지 않은 실무 테스트 유형입니다."),
+    EMPLOYMENT_QUESTION_INVALID_DIFFICULTY(false, HttpStatus.BAD_REQUEST, 2414, "유효하지 않은 난이도입니다."),
+    EMPLOYMENT_QUESTION_INVALID_MEMBER(false, HttpStatus.BAD_REQUEST, 2415, "작성자 정보가 유효하지 않습니다.");
 
     //  면접 일정 - 2500 ~ 2599
 
@@ -52,14 +60,9 @@ public enum ResponseCode {
 
 
     private final boolean success;
-    private final int code;
+    private final HttpStatus httpStatus;        // HTTP 상태 코드
+    private final int code;                     // 비지니스 로직
     private final String message;
-
-    ResponseCode(boolean sucecss, int code, String message) {
-        this.success = sucecss;
-        this.code = code;
-        this.message = message;
-    }
 
     public boolean isSuccess() {
         return success;
@@ -72,4 +75,6 @@ public enum ResponseCode {
     public String getMessage() {
         return message;
     }
+
+    public HttpStatus getHttpStatus() { return httpStatus; }
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtest/command/application/controller/JobtestCommandController.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtest/command/application/controller/JobtestCommandController.java
@@ -1,10 +1,5 @@
 package com.piveguyz.empickbackend.employment.jobtest.command.application.controller;
 
-import com.piveguyz.empickbackend.common.response.ApiResponse;
-import com.piveguyz.empickbackend.employment.jobtest.command.application.dto.CreateQuestionCommandDTO;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtest/command/application/controller/QuestionCommandController.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtest/command/application/controller/QuestionCommandController.java
@@ -9,7 +9,7 @@ import com.piveguyz.empickbackend.employment.jobtest.command.application.service
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.http.HttpStatus;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -37,9 +37,9 @@ public class QuestionCommandController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "2402", description = "회원 정보를 찾을 수 없음")
     })
     @PostMapping
-    public ResponseEntity<CustomApiResponse<CreateQuestionCommandDTO>> createQuestion(@RequestBody CreateQuestionCommandDTO createQuestionCommandDTO) {
+    public ResponseEntity<CustomApiResponse<CreateQuestionCommandDTO>> createQuestion(@RequestBody @Valid CreateQuestionCommandDTO createQuestionCommandDTO) {
         CreateQuestionCommandDTO newQuestionDTO = questionCommandService.createQuestion(createQuestionCommandDTO);
-        return ResponseEntity.status(HttpStatus.CREATED)
+        return ResponseEntity.status(ResponseCode.SUCCESS.getHttpStatus())
                 .body(CustomApiResponse.of(ResponseCode.SUCCESS, newQuestionDTO));
     }
 
@@ -48,12 +48,14 @@ public class QuestionCommandController {
     public ResponseEntity<CustomApiResponse<UpdateQuestionCommandDTO>> updateQuestion(
             @PathVariable int id,
             @RequestBody UpdateQuestionCommandDTO updateQuestionCommandDTO) {
-        return ResponseEntity.ok(CustomApiResponse.of(ResponseCode.SUCCESS, questionCommandService.updateQuestion(updateQuestionCommandDTO)));
+        return ResponseEntity.status(ResponseCode.SUCCESS.getHttpStatus())
+                .body((CustomApiResponse.of(ResponseCode.SUCCESS, questionCommandService.updateQuestion(updateQuestionCommandDTO))));
     }
 
     // 실무 테스트 문제 삭제
     @DeleteMapping("/{id}")
     public ResponseEntity<CustomApiResponse<DeleteQuestionCommandDTO>> deleteQuestion(@PathVariable int id) {
-        return ResponseEntity.ok(CustomApiResponse.of(ResponseCode.SUCCESS, questionCommandService.deleteQuestion(id)));
+        return ResponseEntity.status(ResponseCode.SUCCESS.getHttpStatus())
+                .body(CustomApiResponse.of(ResponseCode.SUCCESS, questionCommandService.deleteQuestion(id)));
     }
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtest/command/application/controller/QuestionCommandController.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtest/command/application/controller/QuestionCommandController.java
@@ -1,16 +1,19 @@
 package com.piveguyz.empickbackend.employment.jobtest.command.application.controller;
 
-import com.piveguyz.empickbackend.common.response.ApiResponse;
+import com.piveguyz.empickbackend.common.response.CustomApiResponse;
 import com.piveguyz.empickbackend.common.response.ResponseCode;
 import com.piveguyz.empickbackend.employment.jobtest.command.application.dto.CreateQuestionCommandDTO;
 import com.piveguyz.empickbackend.employment.jobtest.command.application.dto.DeleteQuestionCommandDTO;
 import com.piveguyz.empickbackend.employment.jobtest.command.application.dto.UpdateQuestionCommandDTO;
 import com.piveguyz.empickbackend.employment.jobtest.command.application.service.QuestionCommandService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-// 문제 등록 관련 API
+@Tag(name = "실무 테스트 문제 API", description = "실무테스트 문제 등록, 수정, 삭제 API")
 @RestController
 @RequestMapping("/api/v1/employment/jobtest/question")
 public class QuestionCommandController {
@@ -20,25 +23,37 @@ public class QuestionCommandController {
         this.questionCommandService = questionCommandService;
     }
 
-    // 실무 테스트 문제 등록
+    @Operation(
+            summary = "실무테스트 문제 등록",
+            description = """
+    - 실무 테스트 문제를 등록합니다.
+    - type : MULTIPLE / SUBJECTIVE / DESCRIPTIVE,
+    - difficulty : EASY / MEDIUM / HARD
+    """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "2400", description = "실무테스트 문제 등록에 실패했습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "2401", description = "동일한 문제가 이미 등록되어 있습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "2402", description = "회원 정보를 찾을 수 없음")
+    })
     @PostMapping
-    public ResponseEntity<ApiResponse<CreateQuestionCommandDTO>> createQuestion(@RequestBody CreateQuestionCommandDTO createQuestionCommandDTO) {
+    public ResponseEntity<CustomApiResponse<CreateQuestionCommandDTO>> createQuestion(@RequestBody CreateQuestionCommandDTO createQuestionCommandDTO) {
         CreateQuestionCommandDTO newQuestionDTO = questionCommandService.createQuestion(createQuestionCommandDTO);
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.of(ResponseCode.SUCCESS, newQuestionDTO));
+                .body(CustomApiResponse.of(ResponseCode.SUCCESS, newQuestionDTO));
     }
 
     // 실무 테스트 문제 수정
     @PutMapping("/{id}")
-    public ResponseEntity<ApiResponse<UpdateQuestionCommandDTO>> updateQuestion(
+    public ResponseEntity<CustomApiResponse<UpdateQuestionCommandDTO>> updateQuestion(
             @PathVariable int id,
             @RequestBody UpdateQuestionCommandDTO updateQuestionCommandDTO) {
-        return ResponseEntity.ok(ApiResponse.of(ResponseCode.SUCCESS, questionCommandService.updateQuestion(updateQuestionCommandDTO)));
+        return ResponseEntity.ok(CustomApiResponse.of(ResponseCode.SUCCESS, questionCommandService.updateQuestion(updateQuestionCommandDTO)));
     }
 
     // 실무 테스트 문제 삭제
     @DeleteMapping("/{id}")
-    public ResponseEntity<ApiResponse<DeleteQuestionCommandDTO>> deleteQuestion(@PathVariable int id) {
-        return ResponseEntity.ok(ApiResponse.of(ResponseCode.SUCCESS, questionCommandService.deleteQuestion(id)));
+    public ResponseEntity<CustomApiResponse<DeleteQuestionCommandDTO>> deleteQuestion(@PathVariable int id) {
+        return ResponseEntity.ok(CustomApiResponse.of(ResponseCode.SUCCESS, questionCommandService.deleteQuestion(id)));
     }
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtest/command/application/service/QuestionCommandServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtest/command/application/service/QuestionCommandServiceImpl.java
@@ -8,23 +8,36 @@ import com.piveguyz.empickbackend.employment.jobtest.command.application.dto.Upd
 import com.piveguyz.empickbackend.employment.jobtest.command.application.mapper.QuestionMapper;
 import com.piveguyz.empickbackend.employment.jobtest.command.domain.aggregate.QuestionEntity;
 import com.piveguyz.empickbackend.employment.jobtest.command.domain.repository.QuestionRepository;
+import com.piveguyz.empickbackend.member.command.domain.repository.MemberRepository;
 import org.springframework.stereotype.Service;
 
 @Service
 public class QuestionCommandServiceImpl implements QuestionCommandService {
 
     private final QuestionRepository questionRepository;
+    private final MemberRepository memberRepository;
 
-    public QuestionCommandServiceImpl(QuestionRepository questionRepository) {
+    public QuestionCommandServiceImpl(QuestionRepository questionRepository,
+                                      MemberRepository memberRepository) {
         this.questionRepository = questionRepository;
+        this.memberRepository = memberRepository;
     }
 
     // 실무 테스트 문제 등록
     @Override
     public CreateQuestionCommandDTO createQuestion(CreateQuestionCommandDTO createQuestionCommandDTO) {
+        // 이미 존재할 경우
         if (questionRepository.existsByContent(createQuestionCommandDTO.getContent())) {
             throw new BusinessException(ResponseCode.EMPLOYMENT_QUESTION_DUPLICATE);
         }
+
+        //
+
+        // 작성자가 없는 회원인 경우
+        if (!memberRepository.existsById(createQuestionCommandDTO.getCreatedMemberId())) {
+            throw new BusinessException(ResponseCode.EMPLOYMENT_QUESTION_INVALID_MEMBER);
+        }
+
 
         QuestionEntity questionEntity = QuestionMapper.toEntity(createQuestionCommandDTO);
         QuestionEntity saved = questionRepository.save(questionEntity);


### PR DESCRIPTION
### 🪄 PR 타입
- [ ] 신규 기능
- [ ] 기능 수정
- [X] 리팩토링
- [ ] 버그 픽스

### #️⃣ 연관된 이슈
close #이슈번호


### 📝 변경 사항
- custion api resonse에 HttpStatus도 함께 저장하게 수정

### 🚩 참고 사항
- 형식 변화로 인해 ResponseCode 필드 값 수정