### PR TITLE
[feat] AuthFacade 구현 (모든 팀원이 확인후에 merge 요망)

### DIFF
--- a/src/main/java/com/piveguyz/empickbackend/auth/facade/AuthFacade.java
+++ b/src/main/java/com/piveguyz/empickbackend/auth/facade/AuthFacade.java
@@ -1,0 +1,62 @@
+package com.piveguyz.empickbackend.auth.facade;
+
+import com.piveguyz.empickbackend.common.constants.RoleCode;
+import com.piveguyz.empickbackend.common.exception.BusinessException;
+import com.piveguyz.empickbackend.common.response.ResponseCode;
+import com.piveguyz.empickbackend.security.CustomMemberDetails;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class AuthFacade {
+
+    public Integer getCurrentMemberId() {
+        Authentication auth = getAuthentication();
+        CustomMemberDetails principal = (CustomMemberDetails) auth.getPrincipal();
+        return principal.getId();
+    }
+
+    public String getCurrentEmployeeNumber() {
+        Authentication auth = getAuthentication();
+        return auth.getName();
+    }
+
+    public List<String> getCurrentUserRoles() {
+        Authentication auth = getAuthentication();
+        return auth.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 특정 권한이 있는지 검증 후 없으면 BusinessException 발생
+     */
+    public void checkHasRole(RoleCode requiredRole) {
+        List<String> roles = getCurrentUserRoles();
+        if (roles.stream().noneMatch(role -> role.equals(requiredRole.name()))) {
+            throw new BusinessException(ResponseCode.MEMBER_CREATED_MEMBER_NO_PERMISSION);
+        }
+    }
+
+    /**
+     * 주어진 권한 중 하나라도 있으면 통과, 없으면 BusinessException 발생
+     */
+    public void checkHasAnyRole(RoleCode... requiredRoles) {
+        List<String> roles = getCurrentUserRoles();
+        boolean hasRole = roles.stream()
+                .anyMatch(role -> List.of(requiredRoles).stream()
+                        .anyMatch(requiredRole -> role.equals(requiredRole.name())));
+        if (!hasRole) {
+            throw new BusinessException(ResponseCode.MEMBER_CREATED_MEMBER_NO_PERMISSION);
+        }
+    }
+
+    private Authentication getAuthentication() {
+        return SecurityContextHolder.getContext().getAuthentication();
+    }
+}

--- a/src/main/java/com/piveguyz/empickbackend/common/constants/RoleCode.java
+++ b/src/main/java/com/piveguyz/empickbackend/common/constants/RoleCode.java
@@ -1,0 +1,19 @@
+package com.piveguyz.empickbackend.common.constants;
+
+public enum RoleCode {
+    ROLE_HR_ACCESS("인사팀 기능 접근"),
+    ROLE_RECRUITMENT_PLAN_EDITOR("채용 계획서 작성"),
+    ROLE_APPROVAL_PROCESSOR("결재 처리 권한"),
+    ROLE_RECRUITMENT_OPERATOR("채용 진행자"),
+    ROLE_USER("일반 사용자");
+
+    private final String description;
+
+    RoleCode(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/piveguyz/empickbackend/common/response/ResponseCode.java
+++ b/src/main/java/com/piveguyz/empickbackend/common/response/ResponseCode.java
@@ -36,6 +36,8 @@ public enum ResponseCode {
     MEMBER_CREATED_MEMBER_ID_REQUIRED(false, HttpStatus.BAD_REQUEST, 1006, "입사처리자가 지정되지 않았습니다."),
     MEMBER_CREATED_MEMBER_NOT_FOUND(false, HttpStatus.NOT_FOUND, 1007, "입사처리자를 찾을 수 없습니다."),
     MEMBER_CREATED_MEMBER_NO_PERMISSION(false, HttpStatus.FORBIDDEN, 1008, "입사처리자는 ROLE_HR_ACCESS 권한이 있어야 합니다."),
+    MEMBER_PROFILE_IMAGE_NOT_FOUND(false, HttpStatus.NOT_FOUND, 1009 , "사원의 프로필 사진을 찾을 수 없습니다." ),
+    MEMBER_ID_INVALID(false, HttpStatus.BAD_REQUEST, 1010, "유효하지 않은 사원 ID 입니다."),
 
     // 채용 오류 - 2000 ~ 2999
     // 채용 공고 - 2000 ~ 2099
@@ -146,7 +148,7 @@ public enum ResponseCode {
 
     // 인증 2700 ~ 2799
     INVALID_REFRESH_TOKEN(false, HttpStatus.UNAUTHORIZED, 2700, "유효하지 않은 Refresh Token입니다."),
-    MEMBER_EMPLOYEE_NUMBER_DUPLICATE(false, HttpStatus.UNAUTHORIZED, 2701, "중복된 사번입니다.");
+    MEMBER_EMPLOYEE_NUMBER_DUPLICATE(false, HttpStatus.UNAUTHORIZED, 2701, "중복된 사번입니다."),;
 
     private final boolean success;
     private final HttpStatus httpStatus;        // HTTP 상태 코드

--- a/src/main/java/com/piveguyz/empickbackend/infra/s3/service/S3Service.java
+++ b/src/main/java/com/piveguyz/empickbackend/infra/s3/service/S3Service.java
@@ -14,4 +14,6 @@ public interface S3Service {
     void delete(String key);
 
     List<String> listFiles(String prefix);
+
+    String generatePublicUrl(String key);
 }

--- a/src/main/java/com/piveguyz/empickbackend/infra/s3/service/S3ServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/infra/s3/service/S3ServiceImpl.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -141,5 +142,10 @@ public class S3ServiceImpl implements S3Service {
             log.error("S3 파일 리스트 조회 실패 - prefix: {}", prefix, e);
             throw new RuntimeException("파일 리스트 조회 실패", e);
         }
+    }
+
+    @Override
+    public String generatePublicUrl(String key) {
+        return String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, key);
     }
 }

--- a/src/main/java/com/piveguyz/empickbackend/member/command/application/controller/MemberCommandController.java
+++ b/src/main/java/com/piveguyz/empickbackend/member/command/application/controller/MemberCommandController.java
@@ -51,12 +51,13 @@ public class MemberCommandController {
     @Operation(summary = "프로필 이미지 업로드", description = "프로필 이미지를 S3에 업로드하고 Member DB에 반영합니다.")
     public ResponseEntity<CustomApiResponse<S3UploadResponseDTO>> uploadProfileImage(
             @PathVariable int memberId,
-            @Parameter(description = "S3 저장 경로 예: profiles/{memberId}", example = "profiles/{memberId}")
-            @RequestParam("prefix") String prefix,
             @Parameter(description = "저장될 파일명 예: profile.png", example = "profile.png")
             @RequestParam("fileName") String fileName,
             @Parameter(description = "업로드할 파일", content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE))
             @RequestPart("file") MultipartFile file) {
+
+        // prefix를 강제로 설정
+        String prefix = "profiles/" + memberId;
 
         MemberProfileUploadRequestDTO request = MemberProfileUploadRequestDTO.builder()
                 .prefix(prefix)
@@ -70,3 +71,4 @@ public class MemberCommandController {
                 .body(CustomApiResponse.of(ResponseCode.CREATED, result));
     }
 }
+

--- a/src/main/java/com/piveguyz/empickbackend/member/command/application/controller/MemberCommandController.java
+++ b/src/main/java/com/piveguyz/empickbackend/member/command/application/controller/MemberCommandController.java
@@ -3,10 +3,14 @@ package com.piveguyz.empickbackend.member.command.application.controller;
 import com.piveguyz.empickbackend.common.constants.ApiExamples;
 import com.piveguyz.empickbackend.common.response.CustomApiResponse;
 import com.piveguyz.empickbackend.common.response.ResponseCode;
+import com.piveguyz.empickbackend.infra.s3.dto.S3UploadResponseDTO;
+import com.piveguyz.empickbackend.member.command.application.dto.MemberProfileUploadRequestDTO;
 import com.piveguyz.empickbackend.member.command.application.dto.MemberSignUpRequestDTO;
 import com.piveguyz.empickbackend.member.command.application.dto.MemberSignUpResponseDTO;
+import com.piveguyz.empickbackend.member.command.application.facade.MemberProfileCommandFacade;
 import com.piveguyz.empickbackend.member.command.application.service.MemberCommandService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -15,11 +19,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/v1/members")
@@ -28,19 +31,41 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberCommandController {
 
     private final MemberCommandService memberCommandService;
+    private final MemberProfileCommandFacade memberProfileFacade;
 
     @PostMapping
     @Operation(summary = "사원 등록", description = "새로운 사원을 등록합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "회원가입 성공",
                     content = @Content(schema = @Schema(implementation = MemberSignUpResponseDTO.class))),
-//            @ApiResponse(responseCode = "1001", description = "삭제된 사원",
-//                    content = @Content(examples = @ExampleObject(value = ApiExamples.ERROR_1001_EXAMPLE))),
             @ApiResponse(responseCode = "409", description = "이메일 중복 오류", content = @Content(examples = @ExampleObject(value = ApiExamples.ERROR_409_EXAMPLE))),
             @ApiResponse(responseCode = "400", description = "유효성 검사 실패", content = @Content(examples = @ExampleObject(value = ApiExamples.ERROR_400_EXAMPLE))),
     })
     public ResponseEntity<CustomApiResponse<MemberSignUpResponseDTO>> signup(@RequestBody @Valid MemberSignUpRequestDTO request) {
         MemberSignUpResponseDTO result = memberCommandService.signUp(request);
+        return ResponseEntity.status(ResponseCode.CREATED.getHttpStatus())
+                .body(CustomApiResponse.of(ResponseCode.CREATED, result));
+    }
+
+    @PostMapping(value = "/{memberId}/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "프로필 이미지 업로드", description = "프로필 이미지를 S3에 업로드하고 Member DB에 반영합니다.")
+    public ResponseEntity<CustomApiResponse<S3UploadResponseDTO>> uploadProfileImage(
+            @PathVariable int memberId,
+            @Parameter(description = "S3 저장 경로 예: profiles/{memberId}", example = "profiles/{memberId}")
+            @RequestParam("prefix") String prefix,
+            @Parameter(description = "저장될 파일명 예: profile.png", example = "profile.png")
+            @RequestParam("fileName") String fileName,
+            @Parameter(description = "업로드할 파일", content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE))
+            @RequestPart("file") MultipartFile file) {
+
+        MemberProfileUploadRequestDTO request = MemberProfileUploadRequestDTO.builder()
+                .prefix(prefix)
+                .fileName(fileName)
+                .file(file)
+                .build();
+
+        S3UploadResponseDTO result = memberProfileFacade.uploadProfileImage(memberId, request);
+
         return ResponseEntity.status(ResponseCode.CREATED.getHttpStatus())
                 .body(CustomApiResponse.of(ResponseCode.CREATED, result));
     }

--- a/src/main/java/com/piveguyz/empickbackend/member/command/application/dto/MemberProfileUploadRequestDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/member/command/application/dto/MemberProfileUploadRequestDTO.java
@@ -1,0 +1,17 @@
+package com.piveguyz.empickbackend.member.command.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class MemberProfileUploadRequestDTO {
+    private String prefix;
+    private String fileName;
+    private MultipartFile file;
+}

--- a/src/main/java/com/piveguyz/empickbackend/member/command/application/facade/MemberProfileCommandFacade.java
+++ b/src/main/java/com/piveguyz/empickbackend/member/command/application/facade/MemberProfileCommandFacade.java
@@ -1,0 +1,49 @@
+package com.piveguyz.empickbackend.member.command.application.facade;
+
+import com.piveguyz.empickbackend.infra.s3.dto.S3UploadResponseDTO;
+import com.piveguyz.empickbackend.infra.s3.service.S3Service;
+import com.piveguyz.empickbackend.member.command.application.dto.MemberProfileUploadRequestDTO;
+import com.piveguyz.empickbackend.member.command.application.service.MemberCommandService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberProfileCommandFacade {
+    private final S3Service s3Service;
+    private final MemberCommandService memberCommandService;
+
+    public String getProfileImageUrl(String key) {
+        return s3Service.generatePublicUrl(key);
+    }
+
+    @Transactional
+    public S3UploadResponseDTO uploadProfileImage(int memberId, MemberProfileUploadRequestDTO request) {
+        S3UploadResponseDTO response = null;
+        try {
+            response = s3Service.uploadFile(
+                    request.getPrefix(),
+                    request.getFileName(),
+                    request.getFile()
+            );
+            memberCommandService.updateProfileImage(memberId, response.getKey());
+            return S3UploadResponseDTO.builder()
+                    .key(response.getKey())
+                    .contentType(response.getContentType())
+                    .size(response.getSize())
+                    .build();
+        } catch (Exception e) {
+            if (response != null) {
+                s3Service.delete(response.getKey());
+            }
+            throw e;
+        }
+    }
+
+    @Transactional
+    public void deleteProfileImage(int memberId, String fileName) {
+        s3Service.delete(fileName);
+        memberCommandService.clearProfileImage(memberId);
+    }
+}

--- a/src/main/java/com/piveguyz/empickbackend/member/command/application/service/MemberCommandService.java
+++ b/src/main/java/com/piveguyz/empickbackend/member/command/application/service/MemberCommandService.java
@@ -5,4 +5,8 @@ import com.piveguyz.empickbackend.member.command.application.dto.MemberSignUpRes
 
 public interface MemberCommandService {
     MemberSignUpResponseDTO signUp(MemberSignUpRequestDTO request);
+
+    void updateProfileImage(int memberId, String key);
+
+    void clearProfileImage(int memberId);
 }

--- a/src/main/java/com/piveguyz/empickbackend/member/command/application/service/MemberCommandServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/member/command/application/service/MemberCommandServiceImpl.java
@@ -79,6 +79,22 @@ public class MemberCommandServiceImpl implements MemberCommandService {
                 .build();
     }
 
+    @Override
+    public void updateProfileImage(int memberId, String key) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ResponseCode.MEMBER_NOT_FOUND));
+
+        member.updateProfileImageUrl(key);
+    }
+
+    @Override
+    public void clearProfileImage(int memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ResponseCode.MEMBER_NOT_FOUND));
+
+        member.clearProfileImageUrl();
+    }
+
     /**
      * 랜덤한 6자리 EmployeeNumber를 생성하고 중복 방지.
      */

--- a/src/main/java/com/piveguyz/empickbackend/member/command/domain/aggregate/Member.java
+++ b/src/main/java/com/piveguyz/empickbackend/member/command/domain/aggregate/Member.java
@@ -90,4 +90,17 @@ public class Member {
 
     @Column(name = "rank_id")
     private Integer rankId;
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updateProfileImageUrl(String key) {
+        this.pictureUrl = key;
+    }
+
+    public void clearProfileImageUrl() {
+        this.pictureUrl = null;
+    }
 }

--- a/src/main/java/com/piveguyz/empickbackend/member/query/controller/MemberQueryController.java
+++ b/src/main/java/com/piveguyz/empickbackend/member/query/controller/MemberQueryController.java
@@ -1,12 +1,12 @@
 package com.piveguyz.empickbackend.member.query.controller;
 
+import com.piveguyz.empickbackend.auth.facade.AuthFacade;
 import com.piveguyz.empickbackend.common.constants.ApiExamples;
 import com.piveguyz.empickbackend.common.response.CustomApiResponse;
 import com.piveguyz.empickbackend.common.response.ResponseCode;
 import com.piveguyz.empickbackend.member.query.dto.MemberResponseDTO;
 import com.piveguyz.empickbackend.member.query.facade.MemberProfileQueryFacade;
 import com.piveguyz.empickbackend.member.query.service.MemberQueryService;
-import com.piveguyz.empickbackend.security.CustomMemberDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -18,7 +18,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "사원 API", description = "사원 등록 및 관리 API")
@@ -29,6 +28,7 @@ public class MemberQueryController {
 
     private final MemberQueryService memberQueryService;
     private final MemberProfileQueryFacade memberProfileQueryFacade;
+    private final AuthFacade authFacade;  // 🔥 AuthFacade 추가
 
     @Operation(summary = "내 정보 조회", description = """
             - 로그인한 사용자의 정보를 조회합니다. (JWT 토큰 필요)
@@ -41,8 +41,9 @@ public class MemberQueryController {
             @ApiResponse(responseCode = "404", description = "회원 정보를 찾을 수 없음", content = @Content(examples = @ExampleObject(value = ApiExamples.ERROR_404_EXAMPLE)))
     })
     @GetMapping("/me")
-    public ResponseEntity<CustomApiResponse<MemberResponseDTO>> getCurrentMember(@AuthenticationPrincipal CustomMemberDetails memberDetails) {
-        MemberResponseDTO responseDTO = memberQueryService.getMemberInfo(memberDetails.getMember().getId());
+    public ResponseEntity<CustomApiResponse<MemberResponseDTO>> getCurrentMember() {
+        Integer memberId = authFacade.getCurrentMemberId();
+        MemberResponseDTO responseDTO = memberQueryService.getMemberInfo(memberId);
         return ResponseEntity.ok(CustomApiResponse.of(ResponseCode.SUCCESS, responseDTO));
     }
 

--- a/src/main/java/com/piveguyz/empickbackend/member/query/facade/MemberProfileQueryFacade.java
+++ b/src/main/java/com/piveguyz/empickbackend/member/query/facade/MemberProfileQueryFacade.java
@@ -1,0 +1,26 @@
+package com.piveguyz.empickbackend.member.query.facade;
+
+import com.piveguyz.empickbackend.common.exception.BusinessException;
+import com.piveguyz.empickbackend.common.response.ResponseCode;
+import com.piveguyz.empickbackend.infra.s3.service.S3Service;
+import com.piveguyz.empickbackend.member.query.service.MemberQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MemberProfileQueryFacade {
+    private final S3Service s3Service;
+    private final MemberQueryService memberQueryService;
+
+    public byte[] downloadProfileImage(int memberId) {
+        // 1. memberId로 pictureUrl 조회
+        String profileImageKey = memberQueryService.getProfileImageKey(memberId);
+        if (profileImageKey == null || profileImageKey.isBlank()) {
+            throw new BusinessException(ResponseCode.MEMBER_PROFILE_IMAGE_NOT_FOUND);
+        }
+
+        // 2. S3에서 다운로드
+        return s3Service.download(profileImageKey);
+    }
+}

--- a/src/main/java/com/piveguyz/empickbackend/member/query/service/MemberQueryService.java
+++ b/src/main/java/com/piveguyz/empickbackend/member/query/service/MemberQueryService.java
@@ -4,4 +4,6 @@ import com.piveguyz.empickbackend.member.query.dto.MemberResponseDTO;
 
 public interface MemberQueryService {
     MemberResponseDTO getMemberInfo(int memberId);
+
+    String getProfileImageKey(int memberId);
 }

--- a/src/main/java/com/piveguyz/empickbackend/member/query/service/MemberQueryServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/member/query/service/MemberQueryServiceImpl.java
@@ -1,5 +1,7 @@
 package com.piveguyz.empickbackend.member.query.service;
 
+import com.piveguyz.empickbackend.common.exception.BusinessException;
+import com.piveguyz.empickbackend.common.response.ResponseCode;
 import com.piveguyz.empickbackend.member.command.domain.aggregate.Member;
 import com.piveguyz.empickbackend.member.command.domain.repository.MemberRepository;
 import com.piveguyz.empickbackend.member.query.dto.MemberResponseDTO;
@@ -23,5 +25,23 @@ public class MemberQueryServiceImpl implements MemberQueryService{
                 member.getEmployeeNumber(),
                 member.getEmail()
         );
+    }
+
+    @Override
+    public String getProfileImageKey(int memberId) {
+        try {
+        } catch (NumberFormatException e) {
+            throw new BusinessException(ResponseCode.MEMBER_ID_INVALID);
+        }
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ResponseCode.MEMBER_NOT_FOUND));
+
+        String pictureUrl = member.getPictureUrl();
+        if (pictureUrl == null || pictureUrl.isBlank()) {
+            throw new BusinessException(ResponseCode.MEMBER_PROFILE_IMAGE_NOT_FOUND);
+        }
+
+        return pictureUrl;
     }
 }

--- a/src/test/java/com/piveguyz/empickbackend/auth/facade/AuthFacadeTest.java
+++ b/src/test/java/com/piveguyz/empickbackend/auth/facade/AuthFacadeTest.java
@@ -1,0 +1,56 @@
+package com.piveguyz.empickbackend.auth.facade;
+
+import com.piveguyz.empickbackend.security.CustomMemberDetails;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class AuthFacadeTest {
+    private AuthFacade authFacade;
+
+    @BeforeEach
+    void setUp() {
+        authFacade = new AuthFacade();
+
+        // Mock CustomMemberDetails
+        CustomMemberDetails memberDetails = Mockito.mock(CustomMemberDetails.class);
+        Mockito.when(memberDetails.getId()).thenReturn(42);
+        Mockito.when(memberDetails.getUsername()).thenReturn("1001");
+
+        // Mock Authorities
+        List<GrantedAuthority> authorities = List.of(
+                (GrantedAuthority) () -> "ROLE_USER",
+                (GrantedAuthority) () -> "ROLE_ADMIN"
+        );
+
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(memberDetails, null, authorities);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @Test
+    void testGetCurrentMemberId() {
+        Integer memberId = authFacade.getCurrentMemberId();
+        assertThat(memberId).isEqualTo(42);
+    }
+
+    @Test
+    void testGetCurrentEmployeeNumber() {
+        String employeeNumber = authFacade.getCurrentEmployeeNumber();
+        assertThat(employeeNumber).isEqualTo("1001");
+    }
+
+    @Test
+    void testGetCurrentUserRoles() {
+        List<String> roles = authFacade.getCurrentUserRoles();
+        assertThat(roles).containsExactlyInAnyOrder("ROLE_USER", "ROLE_ADMIN");
+    }
+}

--- a/src/test/java/com/piveguyz/empickbackend/member/command/application/service/MemberCommandServiceImplTest.java
+++ b/src/test/java/com/piveguyz/empickbackend/member/command/application/service/MemberCommandServiceImplTest.java
@@ -80,9 +80,7 @@ class MemberCommandServiceImplTest {
         request.setPhone("010-1234-5678");
         request.setPictureUrl("https://image.url");
         request.setAddress("서울시");
-        request.setEmployeeNumber(123);
         request.setHireAt(LocalDateTime.now());
-        request.setCreatedMemberId(1);
         request.setStatus(1);
 
         when(memberRepository.findById(1)).thenReturn(Optional.of(new Member()));


### PR DESCRIPTION
### 🪄 PR 타입
- [x] 신규 기능
- [ ] 기능 수정
- [x] 리팩토링
- [ ] 버그 픽스

### #️⃣ 연관된 이슈

close #142 


### 📝 변경 사항

- member 패키지 권한 확인 로직 단순화

----

### 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분

<권한 체크 사용법>

1. AuthFacade의 로그인시 권한을 꺼내오는 메소드
<img width="606" alt="image" src="https://github.com/user-attachments/assets/16fc7d1f-c240-41b3-a5b8-8d8f31d44197" />


2. AuthFacade의  권한 체크 메소드
<img width="687" alt="image" src="https://github.com/user-attachments/assets/bf4e99e1-517f-4ba7-a86b-bcf04bbdb561" />


3. RoleCode
<img width="469" alt="image" src="https://github.com/user-attachments/assets/0f06b5cc-f225-498a-aa6f-6b9770847e6d" />


4. 각 도메인별 서비스에서의 사용 예시 (2. 권한 체크 메소드를 보면 알 수 있듯이 권한이 맞지 않으면 자동으로 예외를 던진다)
<img width="776" alt="스크린샷 2025-06-07 22 58 36" src="https://github.com/user-attachments/assets/d3b8d9c0-a596-4a31-b5d4-67b59e459a67" />
