### PR TITLE
[feat] 면접 평가 점수 Command 기능 구현

### DIFF
--- a/src/main/java/com/piveguyz/empickbackend/common/response/ResponseCode.java
+++ b/src/main/java/com/piveguyz/empickbackend/common/response/ResponseCode.java
@@ -121,6 +121,8 @@ public enum ResponseCode {
     EMPLOYMENT_INTERVIEW_SCORE_NOT_FOUND(false, HttpStatus.BAD_REQUEST, 2550, "존재하지 않습니다."),
     EMPLOYMENT_INTERVIEW_SCORE_NO_SCORE(false, HttpStatus.BAD_REQUEST, 2551, "점수를 입력하지 않았습니다."),
     EMPLOYMENT_INTERVIEW_SCORE_NO_REVIEW(false, HttpStatus.BAD_REQUEST, 2552, "평가를 입력하지 않았습니다."),
+    EMPLOYMENT_INTERVIEW_SCORE_NO_ITEM(false, HttpStatus.BAD_REQUEST, 2553, "해당하는 평가 항목이 존재하지 않습니다."),
+    EMPLOYMENT_INTERVIEW_SCORE_ALREADY_EXIST(false, HttpStatus.BAD_REQUEST, 2554, "이미 평가 점수가 등록되어 있습니다."),
 
 
     //  안내 메일 - 2600 ~ 2699

--- a/src/main/java/com/piveguyz/empickbackend/employment/interviewScore/command/application/controller/InterviewScoreCommandController.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/interviewScore/command/application/controller/InterviewScoreCommandController.java
@@ -1,9 +1,85 @@
 package com.piveguyz.empickbackend.employment.interviewScore.command.application.controller;
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import com.piveguyz.empickbackend.common.response.CustomApiResponse;
+import com.piveguyz.empickbackend.common.response.ResponseCode;
+import com.piveguyz.empickbackend.employment.interviewScore.command.application.dto.InterviewScoreCommandDTO;
+import com.piveguyz.empickbackend.employment.interviewScore.command.application.service.InterviewScoreCommandService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "면접 평가 점수 Command API", description = "면접 평가 점수 관리")
 @RestController
-@RequestMapping("")
+@RequestMapping("api/v1/employment/interviewScore")
 public class InterviewScoreCommandController {
+    private final InterviewScoreCommandService service;
+
+    public InterviewScoreCommandController(InterviewScoreCommandService service) {
+        this.service = service;
+    }
+
+    @Operation(
+            summary = "면접 평가 점수 등록",
+            description = """
+    - 면접 평가 점수를 등록합니다.
+    """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "요청이 성공적으로 처리되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "2551", description = "점수를 입력하지 않았습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "2552", description = "평가를 입력하지 않았습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "2554", description = "이미 평가 점수가 등록되어 있습니다."),
+    })
+    @PostMapping("/create")
+    public ResponseEntity<CustomApiResponse<InterviewScoreCommandDTO>> createInterviewScore(@RequestBody InterviewScoreCommandDTO dto) {
+        InterviewScoreCommandDTO createdDTO = service.create(dto);
+        ResponseCode result = ResponseCode.SUCCESS;
+        return ResponseEntity.status(result.getHttpStatus())
+                .body(CustomApiResponse.of(result, createdDTO));
+    }
+
+    @Operation(
+            summary = "면접 평가 점수 수정",
+            description = """
+    - 면접 평가 점수를 수정합니다.
+    """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "요청이 성공적으로 처리되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "2550", description = "존재하지 않습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "2551", description = "점수를 입력하지 않았습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "2552", description = "평가를 입력하지 않았습니다.")
+    })
+    @PostMapping("/update")
+    public ResponseEntity<CustomApiResponse<InterviewScoreCommandDTO>> updateInterviewScore(@RequestParam("id") Integer id,
+                                                                                            @RequestBody InterviewScoreCommandDTO dto) {
+        InterviewScoreCommandDTO updatedDTO = service.update(id, dto);
+        ResponseCode result = ResponseCode.SUCCESS;
+        return ResponseEntity.status(result.getHttpStatus())
+                .body(CustomApiResponse.of(result, updatedDTO));
+    }
+
+    @Operation(
+            summary = "면접 평가 점수 삭제",
+            description = """
+    - 면접 평가 점수를 삭제합니다.
+    """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "요청이 성공적으로 처리되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "2550", description = "존재하지 않습니다."),
+    })
+    @DeleteMapping("/delete")
+    public ResponseEntity<CustomApiResponse<InterviewScoreCommandDTO>> deleteInterviewScore(@RequestParam("id") Integer id){
+        InterviewScoreCommandDTO deletedDTO = service.delete(id);
+        ResponseCode result = ResponseCode.SUCCESS;
+        return ResponseEntity.status(result.getHttpStatus())
+                .body(CustomApiResponse.of(result, deletedDTO));
+    }
 }
+

--- a/src/main/java/com/piveguyz/empickbackend/employment/interviewScore/command/application/mapper/InterviewScoreCommandMapper.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/interviewScore/command/application/mapper/InterviewScoreCommandMapper.java
@@ -1,0 +1,30 @@
+package com.piveguyz.empickbackend.employment.interviewScore.command.application.mapper;
+
+import com.piveguyz.empickbackend.employment.interviewScore.command.application.dto.InterviewScoreCommandDTO;
+import com.piveguyz.empickbackend.employment.interviewScore.command.domain.aggregate.InterviewScoreEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class InterviewScoreCommandMapper {
+    public InterviewScoreCommandDTO toDto(InterviewScoreEntity entity){
+        InterviewScoreCommandDTO dto = new InterviewScoreCommandDTO();
+        dto.setId(entity.getId());
+        dto.setInterviewId(entity.getInterviewId());
+        dto.setInterviewerId(entity.getInterviewerId());
+        dto.setItemId(entity.getItemId());
+        dto.setScore(entity.getScore());
+        dto.setReview(entity.getReview());
+        return dto;
+    }
+
+    public InterviewScoreEntity toEntity(InterviewScoreCommandDTO dto){
+        InterviewScoreEntity entity = new InterviewScoreEntity();
+        entity.setId(dto.getId());
+        entity.setInterviewId(dto.getInterviewId());
+        entity.setInterviewerId(dto.getInterviewerId());
+        entity.setItemId(dto.getItemId());
+        entity.setScore(dto.getScore());
+        entity.setReview(dto.getReview());
+        return entity;
+    }
+}

--- a/src/main/java/com/piveguyz/empickbackend/employment/interviewScore/command/application/service/InterviewScoreCommandService.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/interviewScore/command/application/service/InterviewScoreCommandService.java
@@ -1,5 +1,12 @@
 package com.piveguyz.empickbackend.employment.interviewScore.command.application.service;
 
 
+import com.piveguyz.empickbackend.employment.interviewScore.command.application.dto.InterviewScoreCommandDTO;
+
 public interface InterviewScoreCommandService {
+    InterviewScoreCommandDTO create(InterviewScoreCommandDTO dto);
+
+    InterviewScoreCommandDTO update(Integer id, InterviewScoreCommandDTO dto);
+
+    InterviewScoreCommandDTO delete(Integer id);
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/interviewScore/command/application/service/InterviewScoreCommandServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/interviewScore/command/application/service/InterviewScoreCommandServiceImpl.java
@@ -1,5 +1,11 @@
 package com.piveguyz.empickbackend.employment.interviewScore.command.application.service;
 
+import com.piveguyz.empickbackend.common.exception.BusinessException;
+import com.piveguyz.empickbackend.common.response.ResponseCode;
+import com.piveguyz.empickbackend.employment.interviewScore.command.application.dto.InterviewScoreCommandDTO;
+import com.piveguyz.empickbackend.employment.interviewScore.command.application.mapper.InterviewScoreCommandMapper;
+import com.piveguyz.empickbackend.employment.interviewScore.command.domain.aggregate.InterviewScoreEntity;
+import com.piveguyz.empickbackend.employment.interviewScore.command.domain.repository.InterviewScoreRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -7,5 +13,59 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-public class InterviewScoreCommandServiceImpl {
+public class InterviewScoreCommandServiceImpl implements InterviewScoreCommandService {
+    private final InterviewScoreRepository repository;
+    private final InterviewScoreCommandMapper mapper;
+
+    @Override
+    public InterviewScoreCommandDTO create(InterviewScoreCommandDTO dto) {
+        Integer interviewId = dto.getInterviewId();
+        Integer interviewerId = dto.getInterviewerId();
+        Integer itemId = dto.getItemId();
+        if(repository.existsByInterviewIdAndInterviewerIdAndItemId(interviewId, interviewerId, itemId)) {
+            throw new BusinessException(ResponseCode.EMPLOYMENT_INTERVIEW_SCORE_ALREADY_EXIST);
+        }
+        Double score = dto.getScore();
+        if(score == null){
+            throw new BusinessException(ResponseCode.EMPLOYMENT_INTERVIEW_SCORE_NO_SCORE);
+        }
+        String review = dto.getReview();
+        if(review == null){
+            throw new BusinessException(ResponseCode.EMPLOYMENT_INTERVIEW_SCORE_NO_REVIEW);
+        }
+        InterviewScoreEntity entity = new InterviewScoreEntity();
+        entity.setInterviewId(dto.getInterviewId());
+        entity.setInterviewerId(dto.getInterviewerId());
+        entity.setItemId(dto.getItemId());
+        entity.setScore(dto.getScore());
+        entity.setReview(dto.getReview());
+        InterviewScoreEntity createdEntity = repository.save(entity);
+        return mapper.toDto(createdEntity);
+    }
+
+    @Override
+    public InterviewScoreCommandDTO update(Integer id, InterviewScoreCommandDTO dto) {
+        Double score = dto.getScore();
+        if(score == null){
+            throw new BusinessException(ResponseCode.EMPLOYMENT_INTERVIEW_SCORE_NO_SCORE);
+        }
+        String review = dto.getReview();
+        if(review == null){
+            throw new BusinessException(ResponseCode.EMPLOYMENT_INTERVIEW_SCORE_NO_REVIEW);
+        }
+        InterviewScoreEntity entity = repository.findById(id)
+                        .orElseThrow(() -> new BusinessException(ResponseCode.EMPLOYMENT_INTERVIEW_SCORE_NOT_FOUND));
+        entity.setScore(dto.getScore());
+        entity.setReview(dto.getReview());
+        InterviewScoreEntity updatedEntity = repository.save(entity);
+        return mapper.toDto(updatedEntity);
+    }
+
+    @Override
+    public InterviewScoreCommandDTO delete(Integer id) {
+        InterviewScoreEntity entity = repository.findById(id)
+                .orElseThrow(() -> new BusinessException(ResponseCode.EMPLOYMENT_INTERVIEW_SCORE_NOT_FOUND));
+        repository.delete(entity);
+        return mapper.toDto(entity);
+    }
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/interviewScore/command/domain/repository/InterviewScoreRepository.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/interviewScore/command/domain/repository/InterviewScoreRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 public interface InterviewScoreRepository extends JpaRepository<InterviewScoreEntity, Integer> {
+
+    boolean existsByInterviewIdAndInterviewerIdAndItemId(Integer interviewId, Integer interviewerId, Integer itemId);
 }


### PR DESCRIPTION
### 🪄 PR 타입
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] 버그 픽스

### #️⃣ 연관된 이슈
#123


### 📝 변경 사항
면접 평가 점수 Command 기능 구현


----

아래 내용은 없을 경우 삭제하면 됩니다.

### 🐛 어떤 위험이나 장애가 발견되었는지 (버그 픽스인 경우)


### 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분
테이블에 현재 등록되어 있는 interview_id를 입력하셔야 됩니다.
item_id의 경우 interview에 해당하는 sheet에 포함된 문항 번호 외에는 점수 입력이 안되도록 추가 구현 예정(현재는 전부 등록이 됨)


### 📷 관련 스크린샷


### 🧪 테스트 계획 또는 완료 사항
- [ ] 면접 평가 점수 등록
[POST] localhost:5001/api/v1/employment/interviewScore/create
@RequestBody
```
{
    "interviewId" : 14,
    "interviewerId" : 1,
    "itemId" : 8,
    "score" : 70,
    "review" : "잘 대답하였습니다."
}
```

- [ ] 면접 평가 점수 수정
[POST] localhost:5001/api/v1/employment/interviewScore/update
@RequestParam("id")
@RequestBody
```
{
    "score" : 80,
    "review" : "아주 잘 대답하였습니다."
}
```

- [ ] 면접 평가 점수 삭제
[DELETE] localhost:5001/api/v1/employment/interviewScore/delete
@RequestParam("id")
