### PR TITLE
[feat] 실무테스트 평가 결과 등록, 수정, 삭제, 조회 구현

### DIFF
--- a/src/main/java/com/piveguyz/empickbackend/common/response/ResponseCode.java
+++ b/src/main/java/com/piveguyz/empickbackend/common/response/ResponseCode.java
@@ -111,6 +111,9 @@ public enum ResponseCode {
     EMPLOYMENT_JOBTEST_DUPLICATE(false, HttpStatus.CONFLICT, 2421, "동일한 이름의 실무테스트가 이미 등록되어 있습니다."),
     EMPLOYMENT_INVALID_JOBTEST(false, HttpStatus.NOT_FOUND, 2422, "요청한 실무테스트를 찾을 수 없습니다."),
 
+    // 평가 결과
+    EMPLOYMENT_INVALID_EVALUATION_RESULT(false, HttpStatus.NOT_FOUND, 2440, "요청한 평가 결과를 찾을 수 없습니다."),
+
 
     //  면접 일정 - 2500 ~ 2599
 

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/evaluation/command/application/controller/EvaluationResultCommandController.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/evaluation/command/application/controller/EvaluationResultCommandController.java
@@ -1,4 +1,81 @@
 package com.piveguyz.empickbackend.employment.jobtests.evaluation.command.application.controller;
 
+
+import com.piveguyz.empickbackend.common.response.CustomApiResponse;
+import com.piveguyz.empickbackend.common.response.ResponseCode;
+import com.piveguyz.empickbackend.employment.jobtests.evaluation.command.application.dto.CreateEvaluationResultCommandDTO;
+import com.piveguyz.empickbackend.employment.jobtests.evaluation.command.application.dto.UpdateEvaluationResultCommandDTO;
+import com.piveguyz.empickbackend.employment.jobtests.evaluation.command.application.service.EvaluationResultCommandService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "실무 테스트 평가 결과 API", description = "실무테스트 평가 결과 등록, 수정, 삭제 API")
+@RestController
+@RequestMapping("/api/v1/employment/jobtest/evaluation-result")
 public class EvaluationResultCommandController {
+    private final EvaluationResultCommandService evaluationResultCommandService;
+
+    public EvaluationResultCommandController(EvaluationResultCommandService evaluationResultCommandService) {
+        this.evaluationResultCommandService = evaluationResultCommandService;
+    }
+    
+    // 실무테스트 평가 결과 등록
+    @Operation(
+            summary = "실무 테스트 평가 결과 등록",
+            description = """
+                     실무 테스트 평가 결과를 등록합니다.
+                    """
+    )
+    @ApiResponses(value = {
+
+    })
+    @PostMapping
+    public ResponseEntity<CustomApiResponse<CreateEvaluationResultCommandDTO>> createEvaluationResult(
+            @RequestBody @Valid CreateEvaluationResultCommandDTO createEvaluationResultCommandDTO) {
+        CreateEvaluationResultCommandDTO newDTO = evaluationResultCommandService.createEvaluationResult(createEvaluationResultCommandDTO);
+        return ResponseEntity.status(ResponseCode.SUCCESS.getHttpStatus())
+                .body(CustomApiResponse.of(ResponseCode.SUCCESS, newDTO));
+    }
+    
+    // 실무테스트 평가 결과 수정
+    @Operation(
+            summary = "실무테스트 평가 결과 수정",
+            description = """
+                    실무테스트 평가 결과를 수정합니다.
+                    """
+    )
+    @ApiResponses(value = {
+
+    })
+    @PatchMapping("/{id}")
+    public ResponseEntity<CustomApiResponse<UpdateEvaluationResultCommandDTO>> updateEvaluationResult(
+            @PathVariable int id,
+            @RequestBody @Valid UpdateEvaluationResultCommandDTO updateEvaluationResultCommandDTO) {
+        UpdateEvaluationResultCommandDTO updated = evaluationResultCommandService.updateEvaluationResult(id, updateEvaluationResultCommandDTO);
+        return ResponseEntity.status(ResponseCode.SUCCESS.getHttpStatus())
+                .body(CustomApiResponse.of(ResponseCode.SUCCESS, updated));
+    }
+    
+    
+    // 실무테스트 평가 결과 삭제
+    @Operation(
+            summary = "실무테스트 평가 결과 삭제",
+            description = """
+                     실무 테스트 평가 결과를 삭제합니다.
+                    """
+    )
+    @ApiResponses(value = {
+
+    })
+    @DeleteMapping("/{id}")
+    public ResponseEntity<CustomApiResponse<Integer>> deleteEvaluationResult(@PathVariable int id) {
+        int deleteId = evaluationResultCommandService.deleteEvaluationResult(id);
+        return ResponseEntity.status(ResponseCode.SUCCESS.getHttpStatus())
+                .body(CustomApiResponse.of(ResponseCode.SUCCESS, deleteId));
+    }
+    
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/evaluation/command/application/dto/CreateEvaluationResultCommandDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/evaluation/command/application/dto/CreateEvaluationResultCommandDTO.java
@@ -1,0 +1,16 @@
+package com.piveguyz.empickbackend.employment.jobtests.evaluation.command.application.dto;
+
+import lombok.*;
+
+@ToString
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CreateEvaluationResultCommandDTO {
+    private String evaluatorComment;
+    private int score;
+
+    private int applicationJobtestId;
+    private int jobtestEvaluationCriteriaId;
+}

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/evaluation/command/application/dto/UpdateEvaluationResultCommandDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/evaluation/command/application/dto/UpdateEvaluationResultCommandDTO.java
@@ -1,0 +1,13 @@
+package com.piveguyz.empickbackend.employment.jobtests.evaluation.command.application.dto;
+
+import lombok.*;
+
+@ToString
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UpdateEvaluationResultCommandDTO {
+    private String evaluatorComment;
+    private Integer score;
+}

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/evaluation/command/application/service/EvaluationResultCommandService.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/evaluation/command/application/service/EvaluationResultCommandService.java
@@ -1,4 +1,13 @@
 package com.piveguyz.empickbackend.employment.jobtests.evaluation.command.application.service;
 
+import com.piveguyz.empickbackend.employment.jobtests.evaluation.command.application.dto.CreateEvaluationResultCommandDTO;
+import com.piveguyz.empickbackend.employment.jobtests.evaluation.command.application.dto.UpdateEvaluationResultCommandDTO;
+import jakarta.validation.Valid;
+
 public interface EvaluationResultCommandService {
+    CreateEvaluationResultCommandDTO createEvaluationResult(@Valid CreateEvaluationResultCommandDTO createEvaluationResultCommandDTO);
+
+    UpdateEvaluationResultCommandDTO updateEvaluationResult(int id, @Valid UpdateEvaluationResultCommandDTO updateEvaluationResultCommandDTO);
+
+    int deleteEvaluationResult(int id);
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/evaluation/command/application/service/EvaluationResultCommandServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/evaluation/command/application/service/EvaluationResultCommandServiceImpl.java
@@ -1,4 +1,63 @@
 package com.piveguyz.empickbackend.employment.jobtests.evaluation.command.application.service;
 
-public class EvaluationResultCommandServiceImpl {
+import com.piveguyz.empickbackend.common.exception.BusinessException;
+import com.piveguyz.empickbackend.common.response.ResponseCode;
+import com.piveguyz.empickbackend.employment.jobtests.evaluation.command.application.dto.CreateEvaluationResultCommandDTO;
+import com.piveguyz.empickbackend.employment.jobtests.evaluation.command.application.dto.UpdateEvaluationResultCommandDTO;
+import com.piveguyz.empickbackend.employment.jobtests.evaluation.command.domain.aggregate.EvaluationResultEntity;
+import com.piveguyz.empickbackend.employment.jobtests.evaluation.command.domain.repository.EvaluationCriteriaRepository;
+import com.piveguyz.empickbackend.employment.jobtests.evaluation.command.domain.repository.EvaluationResultRepository;
+import com.piveguyz.empickbackend.employment.jobtests.evaluation.query.mapper.EvaluationResultMapper;
+import org.springframework.stereotype.Service;
+
+@Service
+public class EvaluationResultCommandServiceImpl implements EvaluationResultCommandService {
+    private final EvaluationResultRepository evaluationResultRepository;
+//    private final EvaluationCriteriaRepository evaluationCriteriaRepository;
+
+    public EvaluationResultCommandServiceImpl(
+//            EvaluationCriteriaRepository evaluationCriteriaRepository,
+                                              EvaluationResultRepository evaluationResultRepository) {
+//        this.evaluationCriteriaRepository = evaluationCriteriaRepository;
+        this.evaluationResultRepository = evaluationResultRepository;
+    }
+
+
+    // 실무테스트 평가 결과 등록
+    @Override
+    public CreateEvaluationResultCommandDTO createEvaluationResult(CreateEvaluationResultCommandDTO createEvaluationResultCommandDTO) {
+        // 🚩 존재하지 않는 지원서별 실무테스트인 경우
+
+
+        // 🚩 존재하지 않는 평가 기준인 경우 (PR 후 합쳐야 함)
+//        if (!evaluationCriteriaRepository.existsById((createEvaluationResultCommandDTO.getJobtestEvaluationCriteriaId()))) {
+//            throw new BusinessException(ResponseCode.EMPLOYMENT_INVALID_EVALUATION_CRITERIA);
+//        }
+
+        EvaluationResultEntity evaluationResultEntity = EvaluationResultMapper.toEntity(createEvaluationResultCommandDTO);
+        EvaluationResultEntity saved = evaluationResultRepository.save(evaluationResultEntity);
+
+        return EvaluationResultMapper.toCreateDto(saved);
+    }
+
+    @Override
+    public UpdateEvaluationResultCommandDTO updateEvaluationResult(int id, UpdateEvaluationResultCommandDTO updateEvaluationResultCommandDTO) {
+        // 평가 결과가 있는지 확인
+        EvaluationResultEntity evaluationResultEntity = evaluationResultRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ResponseCode.EMPLOYMENT_INVALID_EVALUATION_RESULT));
+
+        evaluationResultEntity.updateEvaluationResult(updateEvaluationResultCommandDTO);
+        EvaluationResultEntity saved = evaluationResultRepository.save(evaluationResultEntity);
+
+        return EvaluationResultMapper.toUpdateDto(saved);
+    }
+
+    @Override
+    public int deleteEvaluationResult(int id) {
+        // 평가 결과가 있는지 확인
+        EvaluationResultEntity evaluationResultEntity = evaluationResultRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ResponseCode.EMPLOYMENT_INVALID_EVALUATION_RESULT));
+        evaluationResultRepository.delete(evaluationResultEntity);
+        return evaluationResultEntity.getId();
+    }
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/evaluation/command/domain/aggregate/EvaluationResultEntity.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/evaluation/command/domain/aggregate/EvaluationResultEntity.java
@@ -1,4 +1,42 @@
 package com.piveguyz.empickbackend.employment.jobtests.evaluation.command.domain.aggregate;
 
+import com.piveguyz.empickbackend.employment.jobtests.evaluation.command.application.dto.UpdateEvaluationResultCommandDTO;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@ToString
+@Builder
+@Table(name = "job_test_evaluation_result")
 public class EvaluationResultEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private int id;
+
+    @Column(name = "evaluator_comment", nullable = true)
+    private String evaluatorComment;
+
+    @Column(name = "score", nullable = false)
+    private int score;
+
+    @Column(name = "application_job_test_id", nullable = false)
+    private int applicationJobtestId;
+
+    @Column(name = "job_test_evaluation_criteria_id", nullable = false)
+    private int jobtestEvaluationCriteriaId;
+
+
+    public void updateEvaluationResult(UpdateEvaluationResultCommandDTO dto) {
+        if(dto.getEvaluatorComment() != null) {
+            this.evaluatorComment = dto.getEvaluatorComment();
+        }
+
+        if(dto.getScore() != null) {
+            this.score = dto.getScore();
+        }
+    }
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/evaluation/command/domain/repository/EvaluationResultRepository.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/evaluation/command/domain/repository/EvaluationResultRepository.java
@@ -1,4 +1,9 @@
 package com.piveguyz.empickbackend.employment.jobtests.evaluation.command.domain.repository;
 
-public interface EvaluationResultRepository {
+import com.piveguyz.empickbackend.employment.jobtests.evaluation.command.domain.aggregate.EvaluationResultEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EvaluationResultRepository extends JpaRepository<EvaluationResultEntity, Integer> {
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/evaluation/query/mapper/EvaluationResultMapper.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/evaluation/query/mapper/EvaluationResultMapper.java
@@ -1,4 +1,37 @@
 package com.piveguyz.empickbackend.employment.jobtests.evaluation.query.mapper;
 
+
+import com.piveguyz.empickbackend.employment.jobtests.evaluation.command.application.dto.CreateEvaluationResultCommandDTO;
+import com.piveguyz.empickbackend.employment.jobtests.evaluation.command.application.dto.UpdateEvaluationResultCommandDTO;
+import com.piveguyz.empickbackend.employment.jobtests.evaluation.command.domain.aggregate.EvaluationResultEntity;
+
 public class EvaluationResultMapper {
+
+    // 평가 결과 DTO -> Entity
+    public static EvaluationResultEntity toEntity(CreateEvaluationResultCommandDTO dto) {
+        return EvaluationResultEntity.builder()
+                .evaluatorComment(dto.getEvaluatorComment())
+                .score(dto.getScore())
+                .applicationJobtestId(dto.getApplicationJobtestId())
+                .jobtestEvaluationCriteriaId(dto.getJobtestEvaluationCriteriaId())
+                .build();
+    }
+
+    // Entity -> 평가 결과 생성 DTO
+    public static CreateEvaluationResultCommandDTO toCreateDto(EvaluationResultEntity entity) {
+        return CreateEvaluationResultCommandDTO.builder()
+                .evaluatorComment(entity.getEvaluatorComment())
+                .score(entity.getScore())
+                .applicationJobtestId(entity.getApplicationJobtestId())
+                .jobtestEvaluationCriteriaId(entity.getJobtestEvaluationCriteriaId())
+                .build();
+    }
+
+    // Entity -> 평가 결과 수정 DTO
+    public static UpdateEvaluationResultCommandDTO toUpdateDto(EvaluationResultEntity entity) {
+        return UpdateEvaluationResultCommandDTO.builder()
+                .evaluatorComment(entity.getEvaluatorComment())
+                .score(entity.getScore())
+                .build();
+    }
 }

--- a/src/main/resources/schema/tables/job_test.sql
+++ b/src/main/resources/schema/tables/job_test.sql
@@ -45,7 +45,7 @@ CREATE TABLE application_job_test
     job_test_id         INT      NOT NULL,
     member_id           INT      NOT NULL,
 
-    FOREIGN KEY (`application_id`) REFERENCES `application`(`id`),
+    FOREIGN KEY (`application_id`) REFERENCES `application` (`id`),
     FOREIGN KEY (`job_test_id`) REFERENCES `job_test` (`id`),
     FOREIGN KEY (`member_id`) REFERENCES `member` (`id`)
 );
@@ -103,10 +103,10 @@ CREATE TABLE answer
     attempt                 INT      NOT NULL DEFAULT 1,
     is_correct              TINYINT  NULL,
     application_job_test_id INT      NOT NULL,
-    job_test_question_id    INT      NOT NULL,
+    question_id             INT      NOT NULL,
 
     FOREIGN KEY (`application_job_test_id`) REFERENCES `application_job_test` (`id`),
-    FOREIGN KEY (`job_test_question_id`) REFERENCES `job_test_question` (`id`)
+    FOREIGN KEY (`question_id`) REFERENCES `question` (`id`)
 );
 
 
@@ -132,8 +132,8 @@ CREATE TABLE grading_result
     answer_id                    INT        NOT NULL,
     question_grading_criteria_id INT        NOT NULL,
 
-    FOREIGN KEY (`answer_id`) REFERENCES `answer` (`id`)
-
+    FOREIGN KEY (`answer_id`) REFERENCES `answer` (`id`),
+    FOREIGN KEY (`question_grading_criteria_id`) REFERENCES `question_grading_criteria` (`id`)
 );
 
 


### PR DESCRIPTION
### 🪄 PR 타입
- [X] 신규 기능
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] 버그 픽스

### #️⃣ 연관된 이슈
close #167
close #168 
close #169 


### 📝 변경 사항
- 실무테스트 평가 결과 등록
- 실무테스트 평가 결과 수정
- 실무테스트 평가 결과 삭제
- 실무테스트 평가 결과 조회 : 특정 지원서 id가 입력되면 그에 대한 평가 결과를 조회한다.
나오는 내용
``` 
평가 관련 내용 - 내용, 상세 내용, 가중치, 평가자 코멘트, 평가 점수
실무테스트 정보 - 총 코멘트, 최종 평가 점수, 최종 채점 점수, 평가자 이름
```


### 📷 관련 스크린샷
- 실무테스트 평가 결과 등록
![{656638D5-017D-4C04-A6B1-5BCAC984DCAA}](https://github.com/user-attachments/assets/325b6063-7523-460f-b709-cf8ce75d67b4)

- 실무테스트 평가 결과 수정
![{56D7A0D1-4D19-4776-8778-71C054F0ECE7}](https://github.com/user-attachments/assets/07a15a12-debd-4def-9642-b0901f7b6014)

- 실무테스트 평가 결과 삭제
![{F65F39D2-4A6D-4EA9-A240-5BAEAF23EC11}](https://github.com/user-attachments/assets/2ae176e2-7666-4147-9555-35fdf236782c)

- 실무테스트 평가 결과 조회
![{2DBDB32F-982C-4B1D-82EF-E5F8EC2B3F6F}](https://github.com/user-attachments/assets/7107f190-eaef-4f11-a60d-def87b864068)



### 🧪 테스트 계획 또는 완료 사항
- [ ] 실무테스트 평가 결과 등록 : [POST] /api/v1/employment/jobtest/evaluation-result
- [ ] 실무테스트 평가 결과 수정 : [PATCH] /api/v1/employment/jobtest/evaluation-result/{id}
- [ ] 실무테스트 평가 결과 삭제 : [DELETE] /api/v1/employment/jobtest/evaluation-result/{id}
- [ ] 실무테스트 평가 결과 조회 - 1로 테스트 : [GET] /api/v1/employment/jobtest/evaluation-result/{applicationId}
