### PR TITLE
[feat] 지원서별 실무테스트 답변 등록, 수정, 삭제 구현

### DIFF
--- a/src/main/java/com/piveguyz/empickbackend/common/response/ResponseCode.java
+++ b/src/main/java/com/piveguyz/empickbackend/common/response/ResponseCode.java
@@ -112,6 +112,23 @@ public enum ResponseCode {
     EMPLOYMENT_INVALID_JOBTEST(false, HttpStatus.NOT_FOUND, 2422, "요청한 실무테스트를 찾을 수 없습니다."),
 
 
+
+
+
+
+
+
+
+
+    //   5) 실무테스트 답안
+    EMPLOYMENT_INVALID_JOBTEST_ANSWER(false, HttpStatus.NOT_FOUND,2450, "요청한 답안을 찾을 수 없습니다."),
+
+
+
+    EMPLOYMENT_INVALID_CORRECTED_VALUE(false, HttpStatus.BAD_REQUEST, 2451, "isCorrect 값은 'Y' 또는 'N'이어야 합니다."),
+
+
+
     //  면접 일정 - 2500 ~ 2599
 
 

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/command/application/controller/AnswerCommandController.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/command/application/controller/AnswerCommandController.java
@@ -1,4 +1,79 @@
 package com.piveguyz.empickbackend.employment.jobtests.answer.command.application.controller;
 
+import com.piveguyz.empickbackend.common.response.CustomApiResponse;
+import com.piveguyz.empickbackend.common.response.ResponseCode;
+import com.piveguyz.empickbackend.employment.jobtests.answer.command.application.dto.CreateAnswerCommandDTO;
+import com.piveguyz.empickbackend.employment.jobtests.answer.command.application.dto.UpdateAnswerCommandDTO;
+import com.piveguyz.empickbackend.employment.jobtests.answer.command.application.service.AnswerCommandService;
+import com.piveguyz.empickbackend.employment.jobtests.answer.command.application.dto.CreateAnswerResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "실무테스트 지원서별 답변 API", description = "실무테스트 지원서별 답변 등록, 수정, 삭제 API")
+@RestController
+@RequestMapping("/api/v1/employment/jobtest/answer")
 public class AnswerCommandController {
+    private final AnswerCommandService answerCommandService;
+
+    public AnswerCommandController(AnswerCommandService answerCommandService) {
+        this.answerCommandService = answerCommandService;
+    }
+
+    @Operation(
+            summary = "실무테스트 지원서별 답변 등록",
+            description = """
+                     실무테스트 지원서별 답변을 등록합니다.
+                     isCorrect : WRONG, PARTIAL, CORRECT (null 가능)
+                    """
+    )
+    @ApiResponses(value = {
+    })
+    @PostMapping
+    public ResponseEntity<CustomApiResponse<CreateAnswerResponseDTO>> createAnswer(
+            @RequestBody @Valid CreateAnswerCommandDTO createAnswerCommandDTO) {
+        CreateAnswerResponseDTO newAnswerDTO = answerCommandService.createAnswer(createAnswerCommandDTO);
+        return ResponseEntity.status(ResponseCode.SUCCESS.getHttpStatus())
+                .body(CustomApiResponse.of(ResponseCode.SUCCESS, newAnswerDTO));
+    }
+
+    @Operation(
+            summary = "실무테스트 지원서별 답변 수정",
+            description = """
+                     실무테스트 지원서별 답변을 수정합니다.
+                     정답 여부만 수정 가능합니다.
+                      isCorrect : WRONG, PARTIAL, CORRECT (null 가능)
+                    """
+    )
+    @ApiResponses(value = {
+    })
+    @PatchMapping("/{id}")
+    public ResponseEntity<CustomApiResponse<UpdateAnswerCommandDTO>> updateAnswer(
+            @PathVariable int id,
+            @RequestBody @Valid UpdateAnswerCommandDTO updateAnswerCommandDTO
+    ) {
+        UpdateAnswerCommandDTO updateAnswerDTO = answerCommandService.updateAnswerCommandDTO(id, updateAnswerCommandDTO);
+        return ResponseEntity.status(ResponseCode.SUCCESS.getHttpStatus())
+                .body(CustomApiResponse.of(ResponseCode.SUCCESS, updateAnswerDTO));
+    }
+
+
+    @Operation(
+            summary = "실무테스트 지원서별 답변 삭제",
+            description = """
+                     실무테스트 지원서별 답변을 삭제합니다.
+                    """
+    )
+    @ApiResponses(value = {
+    })
+    @DeleteMapping("/{id}")
+    public ResponseEntity<CustomApiResponse<Integer>> deleteAnswer(
+            @PathVariable int id) {
+        int deleteId = answerCommandService.deleteAnswer(id);
+        return ResponseEntity.status(ResponseCode.SUCCESS.getHttpStatus())
+                .body(CustomApiResponse.of(ResponseCode.SUCCESS, deleteId));
+    }
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/command/application/dto/AnswerCommandDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/command/application/dto/AnswerCommandDTO.java
@@ -1,4 +1,0 @@
-package com.piveguyz.empickbackend.employment.jobtests.answer.command.application.dto;
-
-public class AnswerCommandDTO {
-}

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/command/application/dto/CreateAnswerCommandDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/command/application/dto/CreateAnswerCommandDTO.java
@@ -1,0 +1,17 @@
+package com.piveguyz.empickbackend.employment.jobtests.answer.command.application.dto;
+
+import com.piveguyz.empickbackend.employment.jobtests.answer.command.domain.aggregate.enums.CorrectType;
+import lombok.*;
+
+@ToString
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CreateAnswerCommandDTO {
+    private String content;
+    private CorrectType isCorrect;
+
+    private int applicationJobTestId;
+    private int questionId;
+}

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/command/application/dto/CreateAnswerResponseDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/command/application/dto/CreateAnswerResponseDTO.java
@@ -1,0 +1,15 @@
+package com.piveguyz.empickbackend.employment.jobtests.answer.command.application.dto;
+
+import com.piveguyz.empickbackend.employment.jobtests.answer.command.domain.aggregate.enums.CorrectType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class CreateAnswerResponseDTO {
+    private String content;
+    private CorrectType isCorrect;
+    private int attempt;
+    private int applicationJobTestId;
+    private int questionId;
+}

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/command/application/dto/UpdateAnswerCommandDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/command/application/dto/UpdateAnswerCommandDTO.java
@@ -1,0 +1,13 @@
+package com.piveguyz.empickbackend.employment.jobtests.answer.command.application.dto;
+
+import com.piveguyz.empickbackend.employment.jobtests.answer.command.domain.aggregate.enums.CorrectType;
+import lombok.*;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UpdateAnswerCommandDTO {
+    private CorrectType isCorrect;
+}

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/command/application/mapper/AnswerMapper.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/command/application/mapper/AnswerMapper.java
@@ -1,0 +1,37 @@
+package com.piveguyz.empickbackend.employment.jobtests.answer.command.application.mapper;
+
+import com.piveguyz.empickbackend.employment.jobtests.answer.command.application.dto.CreateAnswerCommandDTO;
+import com.piveguyz.empickbackend.employment.jobtests.answer.command.application.dto.CreateAnswerResponseDTO;
+import com.piveguyz.empickbackend.employment.jobtests.answer.command.application.dto.UpdateAnswerCommandDTO;
+import com.piveguyz.empickbackend.employment.jobtests.answer.command.domain.aggregate.AnswerEntity;
+import com.piveguyz.empickbackend.employment.jobtests.question.command.application.dto.UpdateQuestionCommandDTO;
+import com.piveguyz.empickbackend.employment.jobtests.question.command.domain.aggregate.QuestionEntity;
+
+public class AnswerMapper {
+
+    public static AnswerEntity toEntity(CreateAnswerCommandDTO dto, int attempt) {
+        return AnswerEntity.builder()
+                .content(dto.getContent())
+                .attempt(attempt)
+                .isCorrect(dto.getIsCorrect())
+                .applicationJobTestId(dto.getApplicationJobTestId())
+                .questionId(dto.getQuestionId())
+                .build();
+    }
+
+    public static CreateAnswerResponseDTO toCreateDTO(AnswerEntity entity) {
+        return CreateAnswerResponseDTO.builder()
+                .content(entity.getContent())
+                .isCorrect(entity.getIsCorrect())
+                .attempt(entity.getAttempt())
+                .applicationJobTestId(entity.getApplicationJobTestId())
+                .questionId(entity.getQuestionId())
+                .build();
+    }
+
+    public static UpdateAnswerCommandDTO toUpdateDto(AnswerEntity entity) {
+        return UpdateAnswerCommandDTO.builder()
+                .isCorrect(entity.getIsCorrect())
+                .build();
+    }
+}

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/command/application/service/AnswerCommandService.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/command/application/service/AnswerCommandService.java
@@ -1,4 +1,15 @@
 package com.piveguyz.empickbackend.employment.jobtests.answer.command.application.service;
 
+import com.piveguyz.empickbackend.employment.jobtests.answer.command.application.dto.CreateAnswerCommandDTO;
+import com.piveguyz.empickbackend.employment.jobtests.answer.command.application.dto.CreateAnswerResponseDTO;
+import com.piveguyz.empickbackend.employment.jobtests.answer.command.application.dto.UpdateAnswerCommandDTO;
+import jakarta.validation.Valid;
+
 public interface AnswerCommandService {
+    CreateAnswerResponseDTO createAnswer(@Valid CreateAnswerCommandDTO createAnswerCommandDTO);
+
+    UpdateAnswerCommandDTO updateAnswerCommandDTO(int id, UpdateAnswerCommandDTO updateAnswerCommandDTO);
+
+    Integer deleteAnswer(int id);
+
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/command/application/service/AnswerCommandServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/command/application/service/AnswerCommandServiceImpl.java
@@ -1,4 +1,57 @@
 package com.piveguyz.empickbackend.employment.jobtests.answer.command.application.service;
 
-public class AnswerCommandServiceImpl {
+import com.piveguyz.empickbackend.common.exception.BusinessException;
+import com.piveguyz.empickbackend.common.response.ResponseCode;
+import com.piveguyz.empickbackend.employment.jobtests.answer.command.application.dto.CreateAnswerCommandDTO;
+import com.piveguyz.empickbackend.employment.jobtests.answer.command.application.dto.CreateAnswerResponseDTO;
+import com.piveguyz.empickbackend.employment.jobtests.answer.command.application.dto.UpdateAnswerCommandDTO;
+import com.piveguyz.empickbackend.employment.jobtests.answer.command.domain.aggregate.AnswerEntity;
+import com.piveguyz.empickbackend.employment.jobtests.answer.command.domain.repository.AnswerRepository;
+import com.piveguyz.empickbackend.employment.jobtests.answer.command.application.mapper.AnswerMapper;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class AnswerCommandServiceImpl implements AnswerCommandService {
+
+    private final AnswerRepository answerRepository;
+
+    public AnswerCommandServiceImpl(AnswerRepository answerRepository) {
+        this.answerRepository = answerRepository;
+    }
+
+    // 선택지 등록
+    @Override
+    public CreateAnswerResponseDTO createAnswer(CreateAnswerCommandDTO createAnswerCommandDTO) {
+        int jobTestId = createAnswerCommandDTO.getApplicationJobTestId();
+        int questionId = createAnswerCommandDTO.getQuestionId();
+
+        // 이미 같은 문제에 대한 답이 존재하는 경우 대비
+        Integer maxAttempt = answerRepository.findMaxAttempt(jobTestId, questionId);
+        int nextAttempt = (maxAttempt == null) ? 1 : maxAttempt + 1;
+
+        AnswerEntity entity = AnswerMapper.toEntity(createAnswerCommandDTO, nextAttempt);
+        AnswerEntity saved = answerRepository.save(entity);
+
+        return AnswerMapper.toCreateDTO(saved);
+    }
+
+    @Override
+    public UpdateAnswerCommandDTO updateAnswerCommandDTO(int id, UpdateAnswerCommandDTO updateAnswerCommandDTO) {
+        // 있는지 확인
+        AnswerEntity answer = answerRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ResponseCode.EMPLOYMENT_INVALID_JOBTEST_ANSWER));
+        answer.updateAnswerEntity(updateAnswerCommandDTO);
+        AnswerEntity updated = answerRepository.save(answer);
+        return AnswerMapper.toUpdateDto(updated);
+    }
+
+    // 선택지 삭제
+    @Override
+    public Integer deleteAnswer(int id) {
+        AnswerEntity answer = answerRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ResponseCode.EMPLOYMENT_INVALID_JOBTEST_ANSWER));
+        answerRepository.delete(answer);
+        return answer.getId();
+    }
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/command/domain/aggregate/AnswerEntity.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/command/domain/aggregate/AnswerEntity.java
@@ -1,4 +1,41 @@
 package com.piveguyz.empickbackend.employment.jobtests.answer.command.domain.aggregate;
 
+import com.piveguyz.empickbackend.employment.jobtests.answer.command.application.dto.UpdateAnswerCommandDTO;
+import com.piveguyz.empickbackend.employment.jobtests.answer.command.domain.aggregate.enums.CorrectType;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@ToString
+@Builder
+@Table(name = "answer")
 public class AnswerEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "Id")
+    private int id;
+
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @Column(name = "attempt", nullable = false)
+    private int attempt;
+
+    @Enumerated(EnumType.ORDINAL)
+    @Column(name = "is_correct", nullable = true)
+    private CorrectType isCorrect;
+
+    @Column(name = "application_job_test_id", nullable = false)
+    private int applicationJobTestId;
+
+    @Column(name = "question_id", nullable = false)
+    private int questionId;
+
+    public void updateAnswerEntity(UpdateAnswerCommandDTO dto) {
+        this.isCorrect = dto.getIsCorrect();
+    }
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/command/domain/aggregate/enums/CorrectType.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/command/domain/aggregate/enums/CorrectType.java
@@ -1,0 +1,25 @@
+package com.piveguyz.empickbackend.employment.jobtests.answer.command.domain.aggregate.enums;
+
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+public enum CorrectType {
+    WRONG(0),
+    PARTIAL(1),
+    CORRECT(2);
+
+    private final int code;
+
+    CorrectType(int code) {
+        this.code = code;
+    }
+
+    public static CorrectType fromCode(int code) {
+        return Arrays.stream(CorrectType.values())
+                .filter(d -> d.code == code)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Invalid correct type: " + code));
+    }
+}

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/command/domain/repository/AnswerRepository.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/command/domain/repository/AnswerRepository.java
@@ -1,4 +1,14 @@
 package com.piveguyz.empickbackend.employment.jobtests.answer.command.domain.repository;
 
-public interface AnswerRepository {
+import com.piveguyz.empickbackend.employment.jobtests.answer.command.domain.aggregate.AnswerEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AnswerRepository extends JpaRepository<AnswerEntity, Integer> {
+    @Query("SELECT MAX(a.attempt) FROM AnswerEntity a WHERE a.applicationJobTestId = :jobTestId AND a.questionId = :questionId")
+    Integer findMaxAttempt(@Param("jobTestId") int jobTestId, @Param("questionId") int questionId);
+
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/query/mapper/AnswerMapper.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/query/mapper/AnswerMapper.java
@@ -1,4 +1,7 @@
 package com.piveguyz.empickbackend.employment.jobtests.answer.query.mapper;
 
-public class AnswerMapper {
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface AnswerMapper {
 }


### PR DESCRIPTION
### 🪄 PR 타입
- [X] 신규 기능
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] 버그 픽스

### #️⃣ 연관된 이슈
close #180 
close #181 
close #182 


### 📝 변경 사항
- 지원서별 실무테스트 답변 등록
- 지원서별 실무테스트 답변 수정
- 지원서별 실무테스트 답변 삭제

----

### 📷 관련 스크린샷
- 지원서별 실무테스트 답변 등록
![{4C877954-582E-4DFF-BF40-252CED9FD593}](https://github.com/user-attachments/assets/bd2d65d8-c26b-44f1-8c7d-940ad194f92c)

- 지원서별 실무테스트 답변 수정
![{33516734-22BA-4AAE-95C2-4F22D3691559}](https://github.com/user-attachments/assets/520eccab-7c85-4c04-a392-c189e2ec6d76)

- 지원서별 실무테스트 답변 삭제
![{359BBEAE-71BC-4BB6-B22F-DA9C81F42266}](https://github.com/user-attachments/assets/e7058424-2922-4781-be88-bfaf71e0e88a)

### 🧪 테스트 계획 또는 완료 사항
- [ ] 지원서별 실무테스트 답변 등록 : [POST] /api/v1/employment/jobtest/answer
- [ ] 지원서별 실무테스트 답변 수정 : [PATCH] /api/v1/employment/jobtest/answer/{id}
- [ ] 지원서별 실무테스트 답변 삭제 : [DELETE] /api/v1/employment/jobtest/answer/{id}
