### PR TITLE
[refactor] 채용공고 관련 도메인 API 엔드포인트/필드타입/채용공고 생성 기능 수정

### DIFF
--- a/src/main/java/com/piveguyz/empickbackend/employment/applicationItem/command/application/controller/ApplicationItemCommandController.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/applicationItem/command/application/controller/ApplicationItemCommandController.java
@@ -1,4 +1,0 @@
-package com.piveguyz.empickbackend.employment.applicationItem.command.application.controller;
-
-public class ApplicationItemCommandController {
-}

--- a/src/main/java/com/piveguyz/empickbackend/employment/applicationItem/command/application/dto/ApplicationItemCommandDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/applicationItem/command/application/dto/ApplicationItemCommandDTO.java
@@ -8,5 +8,5 @@ import lombok.*;
 @AllArgsConstructor
 public class ApplicationItemCommandDTO {
 	private int categoryId;
-	private boolean isRequired;
+	private Boolean isRequired;
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/applicationItem/command/application/service/ApplicationItemCommandService.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/applicationItem/command/application/service/ApplicationItemCommandService.java
@@ -1,4 +1,0 @@
-package com.piveguyz.empickbackend.employment.applicationItem.command.application.service;
-
-public interface ApplicationItemCommandService {
-}

--- a/src/main/java/com/piveguyz/empickbackend/employment/applicationItem/command/application/service/ApplicationItemCommandServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/applicationItem/command/application/service/ApplicationItemCommandServiceImpl.java
@@ -1,4 +1,0 @@
-package com.piveguyz.empickbackend.employment.applicationItem.command.application.service;
-
-public class ApplicationItemCommandServiceImpl {
-}

--- a/src/main/java/com/piveguyz/empickbackend/employment/applicationItem/command/domain/aggregate/ApplicationItem.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/applicationItem/command/domain/aggregate/ApplicationItem.java
@@ -20,7 +20,7 @@ public class ApplicationItem {
 
 	@Column(name = "is_required", nullable = false)
 	@Convert(converter = YnBooleanConverter.class)
-	private boolean isRequiredYn;
+	private Boolean isRequiredYn;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "application_item_category_id")

--- a/src/main/java/com/piveguyz/empickbackend/employment/applicationItem/command/domain/aggregate/ApplicationItem.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/applicationItem/command/domain/aggregate/ApplicationItem.java
@@ -1,5 +1,6 @@
 package com.piveguyz.empickbackend.employment.applicationItem.command.domain.aggregate;
 
+import com.piveguyz.empickbackend.common.handler.YnBooleanConverter;
 import com.piveguyz.empickbackend.employment.recruitment.command.domain.aggregate.Recruitment;
 
 import jakarta.persistence.*;
@@ -18,7 +19,8 @@ public class ApplicationItem {
 	private int id;
 
 	@Column(name = "is_required", nullable = false)
-	private String isRequiredYn;
+	@Convert(converter = YnBooleanConverter.class)
+	private boolean isRequiredYn;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "application_item_category_id")

--- a/src/main/java/com/piveguyz/empickbackend/employment/applicationItem/query/dto/ApplicationItemCreateDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/applicationItem/query/dto/ApplicationItemCreateDTO.java
@@ -7,5 +7,5 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ApplicationItemCreateDTO {
 	private int applicationItemCategoryId;
-	private boolean isRequired;
+	private Boolean isRequired;
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/recruitment/command/application/controller/RecruitmentCommandController.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/recruitment/command/application/controller/RecruitmentCommandController.java
@@ -1,6 +1,8 @@
 package com.piveguyz.empickbackend.employment.recruitment.command.application.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -62,7 +64,7 @@ public class RecruitmentCommandController {
 		@ApiResponse(responseCode = "2043", description = "잘못된 상태 전환입니다."),
 		@ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.")
 	})
-	@PutMapping("/status/{id}")
+	@PatchMapping("/{id}/status")
 	public ResponseEntity<CustomApiResponse<Void>> updateStatus(@PathVariable int id, @RequestParam int status) {
 		recruitmentCommandService.updateStatus(id, status);
 		return ResponseEntity.status(ResponseCode.SUCCESS.getHttpStatus())
@@ -76,7 +78,7 @@ public class RecruitmentCommandController {
 		@ApiResponse(responseCode = "2032", description = "이미 삭제된 채용 공고입니다."),
 		@ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.")
 	})
-	@PutMapping("/delete/{id}")
+	@DeleteMapping("/{id}")
 	public ResponseEntity<CustomApiResponse<Void>> delete(@PathVariable int id) {
 		recruitmentCommandService.deleteRecruitment(id);
 		return ResponseEntity.status(ResponseCode.SUCCESS.getHttpStatus())

--- a/src/main/java/com/piveguyz/empickbackend/employment/recruitment/command/application/service/RecruitmentCommandServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/recruitment/command/application/service/RecruitmentCommandServiceImpl.java
@@ -75,7 +75,7 @@ public class RecruitmentCommandServiceImpl implements RecruitmentCommandService 
 			ApplicationItem item = ApplicationItem.builder()
 				.recruitment(saved)
 				.category(category)
-				.isRequiredYn(itemDTO.isRequired() ? "Y" : "N")
+				.isRequiredYn(itemDTO.isRequired())
 				.build();
 
 			applicationItemRepository.save(item);
@@ -131,14 +131,14 @@ public class RecruitmentCommandServiceImpl implements RecruitmentCommandService 
 		for (ApplicationItemCreateDTO itemDTO : dto.getApplicationItems()) {
 			ApplicationItem existing = existingMap.get(itemDTO.getApplicationItemCategoryId());
 			if (existing != null) {
-				existing.setIsRequiredYn(itemDTO.isRequired() ? "Y" : "N");
+				existing.setRequiredYn(itemDTO.isRequired());
 			} else {
 				ApplicationItemCategory category = applicationItemCategoryRepository.findById(itemDTO.getApplicationItemCategoryId())
 					.orElseThrow(() -> new BusinessException(ResponseCode.EMPLOYMENT_APPLICATION_ITEM_CATEGORY_NOT_FOUND));
 				ApplicationItem newItem = ApplicationItem.builder()
 					.recruitment(recruitment)
 					.category(category)
-					.isRequiredYn(itemDTO.isRequired() ? "Y" : "N")
+					.isRequiredYn(itemDTO.isRequired())
 					.build();
 				applicationItemRepository.save(newItem);
 			}

--- a/src/main/java/com/piveguyz/empickbackend/employment/recruitmentTemplate/command/application/controller/RecruitmentTemplateCommandController.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/recruitmentTemplate/command/application/controller/RecruitmentTemplateCommandController.java
@@ -1,6 +1,7 @@
 package com.piveguyz.empickbackend.employment.recruitmentTemplate.command.application.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -62,7 +63,7 @@ public class RecruitmentTemplateCommandController {
 		@ApiResponse(responseCode = "2010", description = "요청한 템플릿을 찾을 수 없습니다."),
 		@ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.")
 	})
-	@PutMapping("/delete/{id}")
+	@DeleteMapping("/{id}")
 	public ResponseEntity<CustomApiResponse<Void>> delete(@PathVariable int id) {
 		recruitmentTemplateCommandService.deleteTemplate(id);
 		return ResponseEntity.status(ResponseCode.SUCCESS.getHttpStatus())

--- a/src/main/java/com/piveguyz/empickbackend/employment/recruitmentTemplate/command/domain/aggregate/RecruitmentTemplate.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/recruitmentTemplate/command/domain/aggregate/RecruitmentTemplate.java
@@ -36,7 +36,7 @@ public class RecruitmentTemplate {
 
 	@Column(name = "is_deleted", nullable = false)
 	@Convert(converter = YnBooleanConverter.class)
-	private boolean isDeleted;
+	private Boolean isDeleted;
 
 	@Column(name = "member_id")
 	private int memberId;

--- a/src/main/java/com/piveguyz/empickbackend/employment/recruitmentTemplate/command/domain/repository/RecruitmentTemplateRepository.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/recruitmentTemplate/command/domain/repository/RecruitmentTemplateRepository.java
@@ -1,8 +1,11 @@
 package com.piveguyz.empickbackend.employment.recruitmentTemplate.command.domain.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.piveguyz.empickbackend.employment.recruitmentTemplate.command.domain.aggregate.RecruitmentTemplate;
 
 public interface RecruitmentTemplateRepository extends JpaRepository<RecruitmentTemplate, Integer> {
+	Optional<RecruitmentTemplate> findByIdAndIsDeletedFalse(int recruitmentTemplateId);
 }


### PR DESCRIPTION
### 🪄 PR 타입
- [ ] 신규 기능
- [ ] 기능 수정
- [x] 리팩토링
- [ ] 버그 픽스

### #️⃣ 연관된 이슈
close #198 
close #200 
close #201 

### 📝 변경 사항
* 삭제여부가 Y인 템플릿으로 공고가 생성 불가하도록 예외처리
* API 엔드포인트 RESTful하게 변경
* 필수여부 컬럼 String -> Boolean 변경

### 🧪 테스트 사항
* 삭제된 템플릿으로 채용공고 생성시
http://localhost:5001/api/v1/employment/recruitment
```
{
  "title": "백엔드 개발자 채용",
  "content": "Spring 기반의 백엔드 개발자를 모집합니다.",
  "recruitType": 0,
  "imageUrl": "https://example.com/logo.png",
  "startedAt": "2025-06-15T00:00:00",
  "endedAt": "2025-07-15T23:59:59",
  "recruitmentTemplateId": 11,
  "introduceTemplateId": 1,
  "memberId": 1,
  "recruitmentRequestId": null,
  "applicationItems": [
    {
      "applicationItemCategoryId": 1,
      "isRequired": true
    },
    {
      "applicationItemCategoryId": 2,
      "isRequired": false
    }
  ],
  "recruitmentProcesses": [
    {
      "stepType": "DOCUMENT",
      "displayOrder": 1
    },
    {
      "stepType": "INTERVIEW",
      "displayOrder": 2
    }
  ]
}
```
![image](https://github.com/user-attachments/assets/afc1c91f-4e36-4987-a25c-f78e63abf251)