### PR TITLE
[refactor] 실무테스트 시작, 종료 일시 추가

### DIFF
--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/application/dto/CreateJobtestCommandDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/application/dto/CreateJobtestCommandDTO.java
@@ -14,6 +14,8 @@ public class CreateJobtestCommandDTO {
     private String title;
     private JobtestDifficulty difficulty;
     private int testTime;
+    private LocalDateTime startedAt;
+    private LocalDateTime endedAt;
 
     private int createdMemberId;
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/application/dto/UpdateJobtestCommandDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/application/dto/UpdateJobtestCommandDTO.java
@@ -3,6 +3,8 @@ package com.piveguyz.empickbackend.employment.jobtests.jobtest.command.applicati
 import com.piveguyz.empickbackend.employment.jobtests.common.enums.JobtestDifficulty;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Getter
 @ToString
 @NoArgsConstructor
@@ -12,6 +14,8 @@ public class UpdateJobtestCommandDTO {
     private String title;
     private JobtestDifficulty difficulty;
     private Integer testTime;
+    private LocalDateTime startedAt;
+    private LocalDateTime endedAt;
 
     private int updatedMemberId;
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/application/mapper/JobtestMapper.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/application/mapper/JobtestMapper.java
@@ -14,6 +14,8 @@ public class JobtestMapper {
                 .title(dto.getTitle())
                 .difficulty(dto.getDifficulty())
                 .testTime(dto.getTestTime())
+                .startedAt(dto.getStartedAt())
+                .endedAt(dto.getEndedAt())
                 .createdAt(LocalDateTime.now())
                 .createdMemberId(dto.getCreatedMemberId())
                 .build();
@@ -25,6 +27,8 @@ public class JobtestMapper {
                 .title(entity.getTitle())
                 .difficulty(entity.getDifficulty())
                 .testTime(entity.getTestTime())
+                .startedAt(entity.getStartedAt())
+                .endedAt(entity.getEndedAt())
                 .createdMemberId(entity.getCreatedMemberId())
                 .build();
     }
@@ -34,6 +38,8 @@ public class JobtestMapper {
                 .title(updatedEntity.getTitle())
                 .difficulty(updatedEntity.getDifficulty())
                 .testTime(updatedEntity.getTestTime())
+                .startedAt(updatedEntity.getStartedAt())
+                .endedAt(updatedEntity.getEndedAt())
                 .updatedMemberId(updatedEntity.getUpdatedMemberId())
                 .build();
     }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/domain/aggregate/JobtestEntity.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/domain/aggregate/JobtestEntity.java
@@ -30,6 +30,12 @@ public class JobtestEntity {
     @Column(name = "test_time", nullable = false)
     private int testTime;
 
+    @Column(name = "started_at", nullable = true)
+    private LocalDateTime startedAt;
+
+    @Column(name = "ended_at", nullable = true)
+    private LocalDateTime endedAt;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
@@ -57,6 +63,12 @@ public class JobtestEntity {
         }
         if(updateJobtestCommandDTO.getTestTime() != null) {
             this.testTime = updateJobtestCommandDTO.getTestTime();
+        }
+        if(updateJobtestCommandDTO.getStartedAt() != null) {
+            this.startedAt = updateJobtestCommandDTO.getStartedAt();
+        }
+        if(updateJobtestCommandDTO.getEndedAt() != null) {
+            this.endedAt = updateJobtestCommandDTO.getEndedAt();
         }
 
         this.updatedMemberId = updateJobtestCommandDTO.getUpdatedMemberId();

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/query/dto/JobtestApplicationsDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/query/dto/JobtestApplicationsDTO.java
@@ -13,6 +13,8 @@ public class JobtestApplicationsDTO {
     private String title;
     private int difficulty;
     private int testTime;
+    private LocalDateTime startedAt;
+    private LocalDateTime endedAt;
     private String creatorName;
     private String updatedName;
     private LocalDateTime createdAt;

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/query/dto/JobtestQueryDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/query/dto/JobtestQueryDTO.java
@@ -13,6 +13,8 @@ public class JobtestQueryDTO {
     private String title;
     private int difficulty;
     private int testTime;
+    private LocalDateTime startedAt;
+    private LocalDateTime endedAt;
     private String creatorName;
     private String updatedName;
     private LocalDateTime createdAt;

--- a/src/main/resources/mapper/jobtest/JobtestMapper.xml
+++ b/src/main/resources/mapper/jobtest/JobtestMapper.xml
@@ -26,6 +26,8 @@
         <result property="title" column="job_test_title"/>
         <result property="difficulty" column="difficulty"/>
         <result property="testTime" column="test_time"/>
+        <result property="startedAt" column="started_at"/>
+        <result property="endedAt" column="ended_at"/>
         <result property="creatorName" column="creator_name"/>
         <result property="updatedName" column="updated_name"/>
         <result property="createdAt" column="created_at"/>
@@ -54,6 +56,8 @@
         <result property="title" column="job_test_title"/>
         <result property="difficulty" column="difficulty"/>
         <result property="testTime" column="test_time"/>
+        <result property="startedAt" column="started_at"/>
+        <result property="endedAt" column="ended_at"/>
         <result property="creatorName" column="creator_name"/>
         <result property="updatedName" column="updated_name"/>
         <result property="createdAt" column="created_at"/>
@@ -73,6 +77,8 @@
                jt.title AS job_test_title,
                jt.difficulty,
                jt.test_time,
+               jt.started_at,
+               jt.ended_at,
                cm.name  AS creator_name,
                um.name  AS updated_name,
                jt.created_at,
@@ -89,6 +95,8 @@
                jt.title            AS job_test_title,
                jt.difficulty,
                jt.test_time,
+               jt.started_at,
+               jt.ended_at,
                cm.name             AS creator_name,
                um.name             AS updated_name,
                jt.created_at,


### PR DESCRIPTION
### 🪄 PR 타입
- [ ] 신규 기능
- [X] 기능 수정
- [ ] 리팩토링
- [ ] 버그 픽스

### #️⃣ 연관된 이슈
close #208


### 📝 변경 사항
- 실무테스트 시작 일시, 종료 일시 추가


### 📷 관련 스크린샷
- 조회 시 시작 일시, 종료 일시 확인 가능
![image](https://github.com/user-attachments/assets/9afd0b1f-78b1-4840-9ab0-52b71aaea85b)


### 🧪 테스트 계획 또는 완료 사항
- [ ] 실무테스트 상세 조회(1번으로 테스트) : [GET] /api/v1/employment/jobtest/{id}
