### PR TITLE
Fix API path prefix for controllers

### DIFF
--- a/src/main/java/com/piveguyz/empickbackend/employment/applicant/command/application/controller/ApplicantBookmarkCommandController.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/applicant/command/application/controller/ApplicantBookmarkCommandController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "지원자 북마크 등록/삭제 API", description = "지원자를 북마크에 등록, 삭제합니다.")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api/v1/employment/applicant-bookmark")
+@RequestMapping("/api/v1/employment/applicant-bookmark")
 public class ApplicantBookmarkCommandController {
 
     private final ApplicantBookmarkCommandService applicantBookmarkCommandService;

--- a/src/main/java/com/piveguyz/empickbackend/employment/applicant/query/controller/ApplicantBookmarkQueryController.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/applicant/query/controller/ApplicantBookmarkQueryController.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 @Tag(name = "ApplicantBookmark", description = "북마크 지원자 조회 API")
 @RestController
-@RequestMapping("api/v1/employment/applicant-bookmark")
+@RequestMapping("/api/v1/employment/applicant-bookmark")
 @RequiredArgsConstructor
 public class ApplicantBookmarkQueryController {
 

--- a/src/main/java/com/piveguyz/empickbackend/employment/applicant/query/controller/ApplicantQueryController.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/applicant/query/controller/ApplicantQueryController.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 @Tag(name = "Applicant", description = "지원자 조회 API")
 @RestController
-@RequestMapping("api/v1/employment/applicant")
+@RequestMapping("/api/v1/employment/applicant")
 @RequiredArgsConstructor
 public class ApplicantQueryController {
 

--- a/src/main/java/com/piveguyz/empickbackend/employment/interview/command/application/controller/InterviewCommandController.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/interview/command/application/controller/InterviewCommandController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 
 @Tag(name="면접 Command API", description="면접 관리")
 @RestController
-@RequestMapping("api/v1/employment/interview")
+@RequestMapping("/api/v1/employment/interview")
 public class InterviewCommandController {
     private final InterviewCommandService service;
 

--- a/src/main/java/com/piveguyz/empickbackend/employment/interview/query/controller/InterviewQueryController.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/interview/query/controller/InterviewQueryController.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 @Tag(name="면접 Query API", description="면접 조회")
 @RestController
-@RequestMapping("api/v1/employment/interview")
+@RequestMapping("/api/v1/employment/interview")
 public class InterviewQueryController {
     private final InterviewQueryService service;
 

--- a/src/main/java/com/piveguyz/empickbackend/employment/interviewCriteria/query/controller/InterviewCriteriaQueryController.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/interviewCriteria/query/controller/InterviewCriteriaQueryController.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 @Tag(name = "면접 평가 기준 Query API", description = "면접 평가 기준 조회")
 @RestController
-@RequestMapping("api/v1/employment/interviewCriteria")
+@RequestMapping("/api/v1/employment/interviewCriteria")
 public class InterviewCriteriaQueryController {
     private final InterviewCriteriaQueryService interviewCriteriaQueryService;
 

--- a/src/main/java/com/piveguyz/empickbackend/employment/interviewScore/command/application/controller/InterviewScoreCommandController.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/interviewScore/command/application/controller/InterviewScoreCommandController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "면접 평가 점수 Command API", description = "면접 평가 점수 관리")
 @RestController
-@RequestMapping("api/v1/employment/interviewScore")
+@RequestMapping("/api/v1/employment/interviewScore")
 public class InterviewScoreCommandController {
     private final InterviewScoreCommandService service;
 

--- a/src/main/java/com/piveguyz/empickbackend/employment/interviewScore/query/controller/InterviewScoreQueryController.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/interviewScore/query/controller/InterviewScoreQueryController.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 @Tag(name = "면접 평가 점수 Query API", description = "면접 평가 점수 조회")
 @RestController
-@RequestMapping("api/v1/employment/interviewScore")
+@RequestMapping("/api/v1/employment/interviewScore")
 public class InterviewScoreQueryController {
     private final InterviewScoreQueryService interviewScoreQueryService;
 

--- a/src/main/java/com/piveguyz/empickbackend/employment/interviewSheet/command/application/controller/InterviewSheetCommandController.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/interviewSheet/command/application/controller/InterviewSheetCommandController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 
 @Tag(name="면접 평가표 Command API", description="면접 평가표 관리")
 @RestController
-@RequestMapping("api/v1/employment/interviewSheet")
+@RequestMapping("/api/v1/employment/interviewSheet")
 public class InterviewSheetCommandController {
     private final InterviewSheetCommandService service;
 

--- a/src/main/java/com/piveguyz/empickbackend/employment/interviewSheet/query/controller/InterviewSheetQueryController.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/interviewSheet/query/controller/InterviewSheetQueryController.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 @Tag(name="면접 평가표 Query API", description="면접 평가표 조회")
 @RestController
-@RequestMapping("api/v1/employment/interviewSheet")
+@RequestMapping("/api/v1/employment/interviewSheet")
 public class InterviewSheetQueryController {
     private final InterviewSheetQueryService service;
 

--- a/src/main/java/com/piveguyz/empickbackend/employment/interviewSheetItem/command/application/controller/InterviewSheetItemCommandController.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/interviewSheetItem/command/application/controller/InterviewSheetItemCommandController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 
 @Tag(name="면접 평가표 항목 Command API", description="면접 평가표 항목 관리")
 @RestController
-@RequestMapping("api/v1/employment/interviewSheetItem")
+@RequestMapping("/api/v1/employment/interviewSheetItem")
 public class InterviewSheetItemCommandController {
     private final InterviewSheetItemCommandService service;
 

--- a/src/main/java/com/piveguyz/empickbackend/employment/interviewSheetItem/query/controller/InterviewSheetItemQueryController.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/interviewSheetItem/query/controller/InterviewSheetItemQueryController.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 @Tag(name="면접 평가표 항목 Query API", description="면접 평가표 항목 조회")
 @RestController
-@RequestMapping("api/v1/employment/interviewSheetItem")
+@RequestMapping("/api/v1/employment/interviewSheetItem")
 public class InterviewSheetItemQueryController {
     private final InterviewSheetItemQueryService service;
 

--- a/src/main/java/com/piveguyz/empickbackend/employment/introduce/query/controller/IntroduceStandardQueryController.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/introduce/query/controller/IntroduceStandardQueryController.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 @Tag(name = "자기소개서 기준표", description = "자기소개ㅐ서 기준표")
 @RequiredArgsConstructor
-@RequestMapping("api/v1/employment/introduce-standard")
+@RequestMapping("/api/v1/employment/introduce-standard")
 @RestController
 public class IntroduceStandardQueryController {
 

--- a/src/main/java/com/piveguyz/empickbackend/employment/mail/command/application/controller/MailCommandController.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/mail/command/application/controller/MailCommandController.java
@@ -15,7 +15,10 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("api/v1/employment/mail")
+// Leading slash clarifies that this mapping is absolute to the server root.
+// While Spring also accepts a path without '/', using it prevents accidental
+// relative path resolutions when combining with method-level mappings.
+@RequestMapping("/api/v1/employment/mail")
 public class MailCommandController {
     private final MailCommandService mailCommandService;
 

--- a/src/main/java/com/piveguyz/empickbackend/employment/mail/query/controller/MailQueryController.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/mail/query/controller/MailQueryController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("api/v1/employment/mail")
+@RequestMapping("/api/v1/employment/mail")
 public class MailQueryController {
     private final MailQueryService mailQueryService;
 

--- a/src/main/java/com/piveguyz/empickbackend/employment/recruitmentRequest/query/controller/RecruitmentRequestQueryController.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/recruitmentRequest/query/controller/RecruitmentRequestQueryController.java
@@ -22,7 +22,7 @@ import lombok.RequiredArgsConstructor;
 
 @Tag(name = "채용 요청서 조회 API", description = "채용 요청서 목록 및 상세 조회")
 @RestController("QueryRecruitmentController")
-@RequestMapping("api/v1/employment/recruitment/request")
+@RequestMapping("/api/v1/employment/recruitment/request")
 @RequiredArgsConstructor
 public class RecruitmentRequestQueryController {
 	private final RecruitmentRequestQueryService recruitmentRequestQueryService;

--- a/src/main/java/com/piveguyz/empickbackend/orgstructure/department/command/application/controller/DeptChangeHistoryCommandController.java
+++ b/src/main/java/com/piveguyz/empickbackend/orgstructure/department/command/application/controller/DeptChangeHistoryCommandController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDateTime;
 
 @RestController
-@RequestMapping("api/v1/dept-change-history")
+@RequestMapping("/api/v1/dept-change-history")
 @Tag(name = "부서 이동 내역 API", description = "부서 이동 내역 생성, 조회 API")
 @RequiredArgsConstructor
 public class DeptChangeHistoryCommandController {


### PR DESCRIPTION
## Summary
- ensure `MailCommandController` uses `/api/v1/employment/mail`
- normalize other controllers to begin paths with `/`
- document why the leading slash is included

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6847de38fa7c83338d179d998c768151