### PR TITLE
[refactor] 채용 요청서 테이블에 직무 컬럼 추가

### DIFF
--- a/src/main/java/com/piveguyz/empickbackend/common/response/ResponseCode.java
+++ b/src/main/java/com/piveguyz/empickbackend/common/response/ResponseCode.java
@@ -67,6 +67,8 @@ public enum ResponseCode {
     EMPLOYMENT_REQUEST_MISSING_QUALIFICATION(false, HttpStatus.BAD_REQUEST, 2005, "자격 요건을 입력해야 합니다."),
     EMPLOYMENT_REQUEST_MISSING_RESPONSIBILITY(false, HttpStatus.BAD_REQUEST, 2006, "담당 업무를 입력해야 합니다."),
     EMPLOYMENT_REQUEST_ALREADY_EXISTS(false, HttpStatus.CONFLICT, 2007, "해당 기간 내 중복된 채용 요청이 존재합니다."),
+    EMPLOYMENT_REQUEST_INVALID_JOB_ID(false, HttpStatus.BAD_REQUEST, 2008, "유효하지 않은 직무 ID입니다."),
+    EMPLOYMENT_REQUEST_INVALID_DEPARTMENT_ID(false, HttpStatus.BAD_REQUEST, 2009, "유효하지 않은 부서 ID입니다."),
 
     // 2) 채용 템플릿
     EMPLOYMENT_TEMPLATE_NOT_FOUND(false, HttpStatus.NOT_FOUND, 2010, "요청한 템플릿을 찾을 수 없습니다."),

--- a/src/main/java/com/piveguyz/empickbackend/employment/recruitmentRequest/command/application/dto/RecruitmentRequestCommandDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/recruitmentRequest/command/application/dto/RecruitmentRequestCommandDTO.java
@@ -2,9 +2,16 @@ package com.piveguyz.empickbackend.employment.recruitmentRequest.command.applica
 
 import java.time.LocalDateTime;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-@Data
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class RecruitmentRequestCommandDTO {
 	private int headcount;
 	private LocalDateTime startedAt;
@@ -16,4 +23,5 @@ public class RecruitmentRequestCommandDTO {
 	private String workLocation;
 	private int memberId;
 	private int departmentId;
+	private int jobId;
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/recruitmentRequest/command/application/service/RecruitmentRequestCommandServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/recruitmentRequest/command/application/service/RecruitmentRequestCommandServiceImpl.java
@@ -1,13 +1,17 @@
 package com.piveguyz.empickbackend.employment.recruitmentRequest.command.application.service;
 
+import static com.piveguyz.empickbackend.common.response.ResponseCode.*;
+
 import java.time.LocalDateTime;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.piveguyz.empickbackend.common.exception.BusinessException;
 import com.piveguyz.empickbackend.employment.recruitmentRequest.command.application.dto.RecruitmentRequestCommandDTO;
 import com.piveguyz.empickbackend.employment.recruitmentRequest.command.domain.aggregate.RecruitmentRequest;
 import com.piveguyz.empickbackend.employment.recruitmentRequest.command.domain.repository.RecruitmentRequestRepository;
+import com.piveguyz.empickbackend.orgstructure.job.command.domain.repository.JobRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -16,9 +20,21 @@ import lombok.RequiredArgsConstructor;
 public class RecruitmentRequestCommandServiceImpl implements RecruitmentRequestCommandService {
 
 	private final RecruitmentRequestRepository recruitmentRequestRepository;
+	private final JobRepository jobRepository;
+	// private final DepartmentRepository departmentRepository;
 
 	@Override
 	public void create(RecruitmentRequestCommandDTO dto) {
+		// 직무 존재 여부 확인
+		if (!jobRepository.existsById(dto.getJobId())) {
+			throw new BusinessException(EMPLOYMENT_REQUEST_INVALID_JOB_ID);
+		}
+
+		// 부서 존재 여부 확인
+		// if (!departmentRepository.existsById(dto.getDepartmentId())) {
+		// 	throw new BusinessException(EMPLOYMENT_REQUEST_INVALID_DEPARTMENT_ID);
+		// }
+
 		RecruitmentRequest request = RecruitmentRequest.builder()
 			.headcount(dto.getHeadcount())
 			.startedAt(dto.getStartedAt())
@@ -30,6 +46,7 @@ public class RecruitmentRequestCommandServiceImpl implements RecruitmentRequestC
 			.workLocation(dto.getWorkLocation())
 			.memberId(dto.getMemberId())
 			.departmentId(dto.getDepartmentId())
+			.jobId(dto.getJobId())
 			.createdAt(LocalDateTime.now())
 			.build();
 

--- a/src/main/java/com/piveguyz/empickbackend/employment/recruitmentRequest/command/domain/aggregate/RecruitmentRequest.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/recruitmentRequest/command/domain/aggregate/RecruitmentRequest.java
@@ -57,4 +57,7 @@ public class RecruitmentRequest {
 
 	@Column(name = "department_id")
 	private int departmentId;
+
+	@Column(name = "job_id")
+	private int jobId;
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/recruitmentRequest/query/dto/RecruitmentRequestQueryDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/recruitmentRequest/query/dto/RecruitmentRequestQueryDTO.java
@@ -2,9 +2,16 @@ package com.piveguyz.empickbackend.employment.recruitmentRequest.query.dto;
 
 import java.time.LocalDateTime;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-@Data
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
 public class RecruitmentRequestQueryDTO {
 	private int id;
 	private int headcount;
@@ -20,4 +27,6 @@ public class RecruitmentRequestQueryDTO {
 	private int departmentId;
 	private String memberName;
 	private String departmentName;
+	private int jobId;
+	private String jobName;
 }

--- a/src/main/resources/mapper/recruitmentRequest/query/mapper/RecruitmentRequestQueryMapper.xml
+++ b/src/main/resources/mapper/recruitmentRequest/query/mapper/RecruitmentRequestQueryMapper.xml
@@ -18,8 +18,10 @@
         <result column="created_at" property="createdAt"/>
         <result column="member_id" property="memberId"/>
         <result column="department_id" property="departmentId"/>
+        <result column="job_id" property="jobId"/>
         <result column="member_name" property="memberName"/>
         <result column="department_name" property="departmentName"/>
+        <result column="job_name" property="jobName"/>
     </resultMap>
 
     <select id="findAll" resultMap="RecruitmentRequestResultMap">
@@ -36,11 +38,14 @@
                rr.created_at,
                rr.member_id,
                rr.department_id,
+               rr.job_id,
                m.name AS member_name,
-               d.name AS department_name
-          FROM recruitment_request rr
+               d.name AS department_name,
+               j.name AS job_name
+        FROM recruitment_request rr
           LEFT JOIN member m ON rr.member_id = m.id
           LEFT JOIN department d ON rr.department_id = d.id
+          LEFT JOIN job j ON rr.job_id = j.id
          ORDER BY rr.created_at DESC
     </select>
 
@@ -58,11 +63,14 @@
                rr.created_at,
                rr.member_id,
                rr.department_id,
+               rr.job_id,
                m.name AS member_name,
-               d.name AS department_name
+               d.name AS department_name,
+               j.name AS job_name
           FROM recruitment_request rr
           LEFT JOIN member m ON rr.member_id = m.id
           LEFT JOIN department d ON rr.department_id = d.id
+          LEFT JOIN job j ON rr.job_id = j.id
          WHERE rr.id = #{id}
     </select>
 

--- a/src/main/resources/schema/tables/recruitment.sql
+++ b/src/main/resources/schema/tables/recruitment.sql
@@ -23,10 +23,12 @@ CREATE TABLE IF NOT EXISTS recruitment_request (
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     member_id INT NOT NULL,
     department_id INT NOT NULL,
+    job_id INT NOT NULL,
 
     CONSTRAINT pk_recruitment_request PRIMARY KEY (id),
     CONSTRAINT fk_recruitment_request_member_id FOREIGN KEY (member_id) REFERENCES member(id),
-    CONSTRAINT fk_recruitment_request_department_id FOREIGN KEY (department_id) REFERENCES department(id)
+    CONSTRAINT fk_recruitment_request_department_id FOREIGN KEY (department_id) REFERENCES department(id),
+    CONSTRAINT fk_recruitment_request_job_id FOREIGN KEY (job_id) REFERENCES job(id)
 );
 
 


### PR DESCRIPTION
### 🪄 PR 타입
- [ ] 신규 기능
- [ ] 기능 수정
- [x] 리팩토링
- [ ] 버그 픽스

### #️⃣ 연관된 이슈
close #235 

### 📝 변경 사항
* 채용 요청서 테이블에 **직무(job_id)** 컬럼 추가
* 직무명을 채용 요청서의 포지션명으로 사용

### 🧪 테스트 완료 사항
- [GET] 채용 요청서 조회
/api/v1/employment/recruitments/requests

- [POST] 채용 요청서 등록
/api/v1/employment/recruitments/requests
```
{
  "headcount": 2,
  "startedAt": "2025-06-10T09:00:00",
  "endedAt": "2025-06-30T18:00:00",
  "qualification": "컴퓨터공학 전공자 우대",
  "preference": "GitHub 활동 활발한 인재",
  "responsibility": "백엔드 API 개발 및 문서화",
  "employmentType": "정규직",
  "workLocation": "서울시 강남구",
  "memberId": 1,
  "departmentId": 1,
  "jobId": 1
}
```