### PR TITLE
[fix] 실무테스트 조회 버그 수정

### DIFF
--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/query/dto/JobtestListQueryDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/query/dto/JobtestListQueryDTO.java
@@ -1,5 +1,6 @@
 package com.piveguyz.empickbackend.employment.jobtests.jobtest.query.dto;
 
+import com.piveguyz.empickbackend.employment.jobtests.common.enums.JobtestDifficulty;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -11,9 +12,11 @@ import java.util.List;
 public class JobtestListQueryDTO {
     private int id;
     private String title;
-    private int difficulty;
+    private JobtestDifficulty difficulty;
     private int createdId;
     private String createdName;
+    private String createMemberPictureUrl;
     private Integer updatedId;
     private String updatedName;
+    private String updatedMemberPictureUrl;
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/query/dto/JobtestQueryDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/query/dto/JobtestQueryDTO.java
@@ -15,7 +15,7 @@ public class JobtestQueryDTO {
     private int testTime;
     private LocalDateTime startedAt;
     private LocalDateTime endedAt;
-    private String creatorName;
+    private String createdName;
     private String updatedName;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/query/dto/JobtestQueryDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/query/dto/JobtestQueryDTO.java
@@ -1,5 +1,6 @@
 package com.piveguyz.empickbackend.employment.jobtests.jobtest.query.dto;
 
+import com.piveguyz.empickbackend.employment.jobtests.common.enums.JobtestDifficulty;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -11,7 +12,7 @@ import java.util.List;
 public class JobtestQueryDTO {
     private int id;
     private String title;
-    private int difficulty;
+    private JobtestDifficulty difficulty;
     private int testTime;
     private LocalDateTime startedAt;
     private LocalDateTime endedAt;

--- a/src/main/resources/mapper/jobtest/JobtestMapper.xml
+++ b/src/main/resources/mapper/jobtest/JobtestMapper.xml
@@ -4,12 +4,13 @@
 
 <mapper namespace="com.piveguyz.empickbackend.employment.jobtests.jobtest.query.mapper.JobtestMapper">
 
-<!--    전체 조회  -->
-    <resultMap id="JobTestMap" type="com.piveguyz.empickbackend.employment.jobtests.jobtest.query.dto.JobtestListQueryDTO">
+    <!--    전체 조회  -->
+    <resultMap id="JobTestMap"
+               type="com.piveguyz.empickbackend.employment.jobtests.jobtest.query.dto.JobtestListQueryDTO">
         <id property="id" column="job_test_id"/>
         <result property="title" column="job_test_title"/>
         <result property="difficulty" column="difficulty"/>
-        <result property="creatorName" column="creator_name"/>
+        <result property="createdName" column="created_name"/>
         <result property="updatedName" column="updated_name"/>
     </resultMap>
 
@@ -47,7 +48,7 @@
         <result property="testTime" column="test_time"/>
         <result property="startedAt" column="started_at"/>
         <result property="endedAt" column="ended_at"/>
-        <result property="creatorName" column="creator_name"/>
+        <result property="createdName" column="created_name"/>
         <result property="updatedName" column="updated_name"/>
         <result property="createdAt" column="created_at"/>
         <result property="updatedAt" column="updated_at"/>
@@ -58,8 +59,6 @@
     </resultMap>
 
 
-
-
     <!--    전체 실무테스트 목록 조회-->
     <select id="findAllJobTests" resultMap="JobTestMap">
         SELECT jt.id    AS job_test_id,
@@ -68,7 +67,7 @@
                jt.test_time,
                jt.started_at,
                jt.ended_at,
-               cm.name  AS creator_name,
+               cm.name  AS created_name,
                um.name  AS updated_name,
                jt.created_at,
                jt.updated_at
@@ -86,7 +85,7 @@
                jt.test_time,
                jt.started_at,
                jt.ended_at,
-               cm.name             AS creator_name,
+               cm.name             AS created_name,
                um.name             AS updated_name,
                jt.created_at,
                jt.updated_at,

--- a/src/main/resources/mapper/jobtest/JobtestMapper.xml
+++ b/src/main/resources/mapper/jobtest/JobtestMapper.xml
@@ -9,9 +9,13 @@
                type="com.piveguyz.empickbackend.employment.jobtests.jobtest.query.dto.JobtestListQueryDTO">
         <id property="id" column="job_test_id"/>
         <result property="title" column="job_test_title"/>
-        <result property="difficulty" column="difficulty"/>
+        <result property="difficulty" column="difficulty"
+                typeHandler="com.piveguyz.empickbackend.employment.jobtests.common.typehandler.JobtestDifficultyTypeHandler"/>
         <result property="createdName" column="created_name"/>
+        <result property="createMemberPictureUrl" column="created_member_picture_url"/>
         <result property="updatedName" column="updated_name"/>
+        <result property="updatedMemberPictureUrl" column="updated_member_picture_url"/>
+
     </resultMap>
 
 
@@ -44,7 +48,9 @@
                type="com.piveguyz.empickbackend.employment.jobtests.jobtest.query.dto.JobtestQueryDTO">
         <id property="id" column="job_test_id"/>
         <result property="title" column="job_test_title"/>
-        <result property="difficulty" column="difficulty"/>
+        <result property="difficulty" column="difficulty"
+                typeHandler="com.piveguyz.empickbackend.employment.jobtests.common.typehandler.JobtestDifficultyTypeHandler"/>
+
         <result property="testTime" column="test_time"/>
         <result property="startedAt" column="started_at"/>
         <result property="endedAt" column="ended_at"/>
@@ -61,14 +67,16 @@
 
     <!--    전체 실무테스트 목록 조회-->
     <select id="findAllJobTests" resultMap="JobTestMap">
-        SELECT jt.id    AS job_test_id,
-               jt.title AS job_test_title,
+        SELECT jt.id          AS job_test_id,
+               jt.title       AS job_test_title,
                jt.difficulty,
                jt.test_time,
                jt.started_at,
                jt.ended_at,
-               cm.name  AS created_name,
-               um.name  AS updated_name,
+               cm.name        AS created_name,
+               cm.picture_url AS createMemberPictureUrl,
+               um.name        AS updated_name,
+               um.picture_url AS updatedMemberPictureUrl,
                jt.created_at,
                jt.updated_at
         FROM job_test jt

--- a/src/main/resources/mapper/jobtest/QuestionMapper.xml
+++ b/src/main/resources/mapper/jobtest/QuestionMapper.xml
@@ -78,8 +78,8 @@
                q.created_member_id,
                q.updated_member_id,
 
-               cm.name AS created_member_name,
-               um.name AS updated_member_name,
+               cm.name        AS created_member_name,
+               um.name        AS updated_member_name,
 
                cm.picture_url AS created_member_picture_url,
                um.picture_url AS updated_member_picture_url


### PR DESCRIPTION
### 🪄 PR 타입
- [ ] 신규 기능
- [ ] 기능 수정
- [ ] 리팩토링
- [X] 버그 픽스

### #️⃣ 연관된 이슈
close #이슈번호


### 📝 변경 사항
- 실무테스트 변수 이름 변경으로 조회가 안되던 버그 수정


### 📷 관련 스크린샷
![{772E8E2D-2BAC-498E-A7F7-5E23E1AE850C}](https://github.com/user-attachments/assets/6fc4617f-9f89-4f8f-a901-71ad2cbb3c03)


### 🧪 테스트 계획 또는 완료 사항
- [ ] 실무테스트 전체 조회 : [GET] /api/v1/employment/jobtests
