### PR TITLE
[refactor] 채용 요청서 등록 로직 수정

### DIFF
--- a/src/main/java/com/piveguyz/empickbackend/employment/recruitmentRequest/command/application/controller/RecruitmentRequestCommandController.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/recruitmentRequest/command/application/controller/RecruitmentRequestCommandController.java
@@ -1,20 +1,25 @@
 package com.piveguyz.empickbackend.employment.recruitmentRequest.command.application.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.piveguyz.empickbackend.auth.command.jwt.JwtProvider;
+import com.piveguyz.empickbackend.common.exception.BusinessException;
 import com.piveguyz.empickbackend.common.response.CustomApiResponse;
 import com.piveguyz.empickbackend.common.response.ResponseCode;
 import com.piveguyz.empickbackend.employment.recruitmentRequest.command.application.dto.RecruitmentRequestCommandDTO;
 import com.piveguyz.empickbackend.employment.recruitmentRequest.command.application.service.RecruitmentRequestCommandService;
+import com.piveguyz.empickbackend.security.CustomMemberDetails;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 
 @Tag(name = "채용 공고 API", description = "채용 공고 관련 전체 API")
@@ -24,6 +29,7 @@ import lombok.RequiredArgsConstructor;
 public class RecruitmentRequestCommandController {
 
 	private final RecruitmentRequestCommandService recruitmentRequestCommandService;
+	private final JwtProvider jwtProvider;
 
 	@Operation(
 		summary = "채용 요청서 등록",
@@ -39,8 +45,28 @@ public class RecruitmentRequestCommandController {
 		@ApiResponse(responseCode = "500", description = "서버 내부 오류입니다.")
 	})
 	@PostMapping
-	public ResponseEntity<CustomApiResponse<Void>> create(@RequestBody RecruitmentRequestCommandDTO dto) {
-		recruitmentRequestCommandService.create(dto);
+	public ResponseEntity<CustomApiResponse<Void>> create(
+		@RequestBody RecruitmentRequestCommandDTO dto,
+		@AuthenticationPrincipal CustomMemberDetails memberDetails,
+		HttpServletRequest request) {
+
+		int memberId;
+
+		// 1. 인증 객체에서 꺼내기
+		if (memberDetails != null) {
+			memberId = memberDetails.getId();
+		} else {
+			// 2. 인증 객체가 없을 경우 토큰에서 직접 추출
+			String token = request.getHeader("Authorization");
+			if (token != null && token.startsWith("Bearer ")) {
+				token = token.substring(7); // "Bearer " 제거
+				memberId = jwtProvider.getMemberIdFromToken(token); // ⬅️ 이 메서드는 JwtProvider에 있어야 함
+			} else {
+				throw new BusinessException(ResponseCode.UNAUTHORIZED);
+			}
+		}
+
+		recruitmentRequestCommandService.create(dto, memberId);
 		return ResponseEntity.status(ResponseCode.SUCCESS.getHttpStatus())
 			.body(CustomApiResponse.of(ResponseCode.SUCCESS));
 	}

--- a/src/main/java/com/piveguyz/empickbackend/employment/recruitmentRequest/command/application/dto/RecruitmentRequestCommandDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/recruitmentRequest/command/application/dto/RecruitmentRequestCommandDTO.java
@@ -21,7 +21,6 @@ public class RecruitmentRequestCommandDTO {
 	private String responsibility;
 	private String employmentType;
 	private String workLocation;
-	private int memberId;
 	private int departmentId;
 	private int jobId;
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/recruitmentRequest/command/application/service/RecruitmentRequestCommandService.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/recruitmentRequest/command/application/service/RecruitmentRequestCommandService.java
@@ -3,5 +3,5 @@ package com.piveguyz.empickbackend.employment.recruitmentRequest.command.applica
 import com.piveguyz.empickbackend.employment.recruitmentRequest.command.application.dto.RecruitmentRequestCommandDTO;
 
 public interface RecruitmentRequestCommandService {
-	void create(RecruitmentRequestCommandDTO dto);
+	void create(RecruitmentRequestCommandDTO dto, int memberId);
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/recruitmentRequest/command/application/service/RecruitmentRequestCommandServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/recruitmentRequest/command/application/service/RecruitmentRequestCommandServiceImpl.java
@@ -5,13 +5,13 @@ import static com.piveguyz.empickbackend.common.response.ResponseCode.*;
 import java.time.LocalDateTime;
 
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.piveguyz.empickbackend.common.exception.BusinessException;
 import com.piveguyz.empickbackend.employment.recruitmentRequest.command.application.dto.RecruitmentRequestCommandDTO;
 import com.piveguyz.empickbackend.employment.recruitmentRequest.command.domain.aggregate.RecruitmentRequest;
 import com.piveguyz.empickbackend.employment.recruitmentRequest.command.domain.repository.RecruitmentRequestRepository;
 import com.piveguyz.empickbackend.orgstructure.job.command.domain.repository.JobRepository;
+import com.piveguyz.empickbackend.orgstructure.member.command.domain.repository.MemberRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -20,11 +20,12 @@ import lombok.RequiredArgsConstructor;
 public class RecruitmentRequestCommandServiceImpl implements RecruitmentRequestCommandService {
 
 	private final RecruitmentRequestRepository recruitmentRequestRepository;
+	private final MemberRepository memberRepository;
 	private final JobRepository jobRepository;
 	// private final DepartmentRepository departmentRepository;
 
 	@Override
-	public void create(RecruitmentRequestCommandDTO dto) {
+	public void create(RecruitmentRequestCommandDTO dto, int memberId) {
 		// 직무 존재 여부 확인
 		if (!jobRepository.existsById(dto.getJobId())) {
 			throw new BusinessException(EMPLOYMENT_REQUEST_INVALID_JOB_ID);
@@ -44,7 +45,7 @@ public class RecruitmentRequestCommandServiceImpl implements RecruitmentRequestC
 			.responsibility(dto.getResponsibility())
 			.employmentType(dto.getEmploymentType())
 			.workLocation(dto.getWorkLocation())
-			.memberId(dto.getMemberId())
+			.memberId(memberId)
 			.departmentId(dto.getDepartmentId())
 			.jobId(dto.getJobId())
 			.createdAt(LocalDateTime.now())


### PR DESCRIPTION
### 🪄 PR 타입
- [ ] 신규 기능
- [ ] 기능 수정
- [x] 리팩토링
- [ ] 버그 픽스

### #️⃣ 연관된 이슈
close #251 

### 📝 변경 사항
* JWT에서 memberId 추출하도록 채용 요청서 등록 로직 수정

### 📷 관련 스크린샷
![image](https://github.com/user-attachments/assets/c43477b7-49eb-4c09-bd35-f0b9c53870e0)

### 🧪 테스트 완료 사항
- [POST] 채용 요청서 등록  ( 토큰 입력 후 등록 )
localhost:5001/api/v1/employment/recruitments/requests
```
{
  "headcount": 2,
  "startedAt": "2025-06-10T09:00:00",
  "endedAt": "2025-06-30T18:00:00",
  "qualification": "컴퓨터공학 전공자 우대",
  "preference": "GitHub 활동 활발한 인재",
  "responsibility": "백엔드 API 개발 및 문서화",
  "employmentType": "정규직",
  "workLocation": "서울시 강남구",
  "departmentId": 10,
  "jobId": 1
}
```
