### PR TITLE
feat: 실무테스트 답안 조회 구현

### DIFF
--- a/src/main/java/com/piveguyz/empickbackend/common/handler/AnswerIsCorrectHandler.java
+++ b/src/main/java/com/piveguyz/empickbackend/common/handler/AnswerIsCorrectHandler.java
@@ -1,0 +1,35 @@
+package com.piveguyz.empickbackend.common.handler;
+
+import com.piveguyz.empickbackend.employment.jobtests.answer.command.domain.aggregate.enums.CorrectType;
+import org.apache.ibatis.type.BaseTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.MappedTypes;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+@MappedTypes(CorrectType.class)
+public class AnswerIsCorrectHandler  extends BaseTypeHandler<CorrectType> {
+
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int i, CorrectType parameter, JdbcType jdbcType) throws SQLException {
+        ps.setInt(i, parameter.getCode());
+    }
+
+    @Override
+    public CorrectType getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        return CorrectType.fromCode(rs.getInt(columnName));
+    }
+
+    @Override
+    public CorrectType getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        return CorrectType.fromCode(rs.getInt(columnIndex));
+    }
+
+    @Override
+    public CorrectType getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        return CorrectType.fromCode(cs.getInt(columnIndex));
+    }
+}

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/query/controller/AnswerQueryController.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/query/controller/AnswerQueryController.java
@@ -1,4 +1,28 @@
 package com.piveguyz.empickbackend.employment.jobtests.answer.query.controller;
 
+import com.piveguyz.empickbackend.common.response.CustomApiResponse;
+import com.piveguyz.empickbackend.common.response.ResponseCode;
+import com.piveguyz.empickbackend.employment.jobtests.answer.query.dto.AnswerQueryDTO;
+import com.piveguyz.empickbackend.employment.jobtests.answer.query.service.AnswerQueryService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "실무테스트 API", description = "실무테스트 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/employment/answers")
 public class AnswerQueryController {
+
+    private final AnswerQueryService answerQueryService;
+
+    @GetMapping("/{applicationJobtestId}")
+    public ResponseEntity<CustomApiResponse<List<AnswerQueryDTO>>> getAnswerList(@PathVariable int applicationJobtestId) {
+        List<AnswerQueryDTO> result =answerQueryService.findAnswerWithApplicationJobtestId(applicationJobtestId);
+        return ResponseEntity.status(ResponseCode.SUCCESS.getHttpStatus())
+                .body(CustomApiResponse.of(ResponseCode.SUCCESS, result));
+    }
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/query/dto/AnswerQueryDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/query/dto/AnswerQueryDTO.java
@@ -1,4 +1,28 @@
 package com.piveguyz.empickbackend.employment.jobtests.answer.query.dto;
 
+import com.piveguyz.empickbackend.employment.jobtests.answer.command.domain.aggregate.enums.CorrectType;
+import com.piveguyz.empickbackend.employment.jobtests.question.query.dto.QuestionQueryDTO;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
 public class AnswerQueryDTO {
+    private int id;
+    private String content;
+    private int attempt;
+    private CorrectType isCorrect; // 0/1/2 (ENUM)
+    private Double score;
+    private int applicationJobTestId;
+    private int questionId;
+
+    private int maxScore;
+
+    // 문제 정보 포함 (QuestionQueryDTO)
+    private QuestionQueryDTO question;
+
+    // 답변의 채점 결과
+    private List<GradingResultQueryDTO> gradingResults;
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/query/dto/GradingResultQueryDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/query/dto/GradingResultQueryDTO.java
@@ -1,4 +1,16 @@
 package com.piveguyz.empickbackend.employment.jobtests.answer.query.dto;
 
+import lombok.*;
+
+@ToString
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Setter
 public class GradingResultQueryDTO {
+    private int id;
+    private int gradingCriteriaId;
+    private boolean isSatisfied;
+    private int answerId;
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/query/mapper/AnswerMapper.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/query/mapper/AnswerMapper.java
@@ -1,7 +1,11 @@
 package com.piveguyz.empickbackend.employment.jobtests.answer.query.mapper;
 
+import com.piveguyz.empickbackend.employment.jobtests.answer.query.dto.AnswerQueryDTO;
 import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
 
 @Mapper
 public interface AnswerMapper {
+    List<AnswerQueryDTO> findAnswerWithApplicationJobtestId(int applicationJobtestId);
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/query/service/AnswerQueryService.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/query/service/AnswerQueryService.java
@@ -1,4 +1,9 @@
 package com.piveguyz.empickbackend.employment.jobtests.answer.query.service;
 
+import com.piveguyz.empickbackend.employment.jobtests.answer.query.dto.AnswerQueryDTO;
+
+import java.util.List;
+
 public interface AnswerQueryService {
+    List<AnswerQueryDTO> findAnswerWithApplicationJobtestId(int applicationJobtestId);
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/query/service/AnswerQueryServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/query/service/AnswerQueryServiceImpl.java
@@ -1,4 +1,19 @@
 package com.piveguyz.empickbackend.employment.jobtests.answer.query.service;
 
-public class AnswerQueryServiceImpl {
+import com.piveguyz.empickbackend.employment.jobtests.answer.query.dto.AnswerQueryDTO;
+import com.piveguyz.empickbackend.employment.jobtests.answer.query.mapper.AnswerMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AnswerQueryServiceImpl implements AnswerQueryService {
+    private final AnswerMapper answerMapper;
+
+    @Override
+    public List<AnswerQueryDTO> findAnswerWithApplicationJobtestId(int applicationJobtestId) {
+        return answerMapper.findAnswerWithApplicationJobtestId(applicationJobtestId);
+    }
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/grading/query/dto/GradingCriteriaQueryDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/grading/query/dto/GradingCriteriaQueryDTO.java
@@ -9,6 +9,7 @@ import lombok.*;
 @Builder
 @Setter
 public class GradingCriteriaQueryDTO {
+    private int id;
     private String content;
     private String detailContent;
     private double scoreWeight;

--- a/src/main/resources/mapper/jobtest/AnswerMapper.xml
+++ b/src/main/resources/mapper/jobtest/AnswerMapper.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.piveguyz.empickbackend.employment.jobtests.answer.query.mapper.AnswerMapper">
+
+    <!-- QuestionOptionDTO -->
+    <resultMap id="QuestionOptionMap"
+               type="com.piveguyz.empickbackend.employment.jobtests.question.query.dto.QuestionOptionDTO">
+        <id property="id" column="qo_id"/>
+        <result property="optionNumber" column="qo_option_number"/>
+        <result property="content" column="qo_content"/>
+    </resultMap>
+
+    <!-- GradingCriteriaQueryDTO -->
+    <resultMap id="GradingCriteriaMap"
+               type="com.piveguyz.empickbackend.employment.jobtests.grading.query.dto.GradingCriteriaQueryDTO">
+        <id property="id" column="gc_id"/>
+        <result property="content" column="gc_content"/>
+        <result property="scoreWeight" column="gc_score_weight"/>
+    </resultMap>
+
+    <!-- QuestionQueryDTO -->
+    <resultMap id="QuestionMap"
+               type="com.piveguyz.empickbackend.employment.jobtests.question.query.dto.QuestionQueryDTO">
+        <id property="id" column="q_id"/>
+        <result property="content" column="q_content"/>
+        <result property="detailContent" column="q_detail_content"/>
+        <result property="type" column="q_type"
+                typeHandler="com.piveguyz.empickbackend.employment.jobtests.common.typehandler.QuestionTypeHandler"/>
+        <result property="difficulty" column="q_difficulty"
+                typeHandler="com.piveguyz.empickbackend.employment.jobtests.common.typehandler.JobtestDifficultyTypeHandler"/>
+        <result property="answer" column="q_answer"/>
+        <!-- 선지 -->
+        <collection property="options"
+                    ofType="com.piveguyz.empickbackend.employment.jobtests.question.query.dto.QuestionOptionDTO"
+                    resultMap="QuestionOptionMap"/>
+        <!-- 채점 기준 -->
+        <collection property="gradingCriteria"
+                    ofType="com.piveguyz.empickbackend.employment.jobtests.grading.query.dto.GradingCriteriaQueryDTO"
+                    resultMap="GradingCriteriaMap"/>
+    </resultMap>
+
+    <!-- GradingResultQueryDTO -->
+    <resultMap id="GradingResultMap"
+               type="com.piveguyz.empickbackend.employment.jobtests.answer.query.dto.GradingResultQueryDTO">
+        <id property="id" column="gr_id"/>
+        <result property="gradingCriteriaId" column="gr_grading_criteria_id"/>
+        <result property="isSatisfied" column="gr_is_satisfied"/>
+        <result property="answerId" column="gr_answer_id"/>
+    </resultMap>
+
+    <!-- 최상위 AnswerQueryDTO -->
+    <resultMap id="AnswerWithFullMap"
+               type="com.piveguyz.empickbackend.employment.jobtests.answer.query.dto.AnswerQueryDTO">
+        <id property="id" column="a_id"/>
+        <result property="content" column="a_content"/>
+        <result property="attempt" column="a_attempt"/>
+        <result property="isCorrect" column="a_is_correct"
+                typeHandler="com.piveguyz.empickbackend.common.handler.AnswerIsCorrectHandler"/>
+        <result property="score" column="a_score"/>
+        <result property="applicationJobTestId" column="a_application_job_test_id"/>
+        <result property="questionId" column="a_question_id"/>
+
+        <result property="maxScore" column="jq_score"/>
+        <!-- 문제 -->
+        <association property="question"
+                     javaType="com.piveguyz.empickbackend.employment.jobtests.question.query.dto.QuestionQueryDTO"
+                     resultMap="QuestionMap"/>
+        <!-- 채점 결과 -->
+        <collection property="gradingResults"
+                    ofType="com.piveguyz.empickbackend.employment.jobtests.answer.query.dto.GradingResultQueryDTO"
+                    resultMap="GradingResultMap"/>
+    </resultMap>
+
+    <!-- 실제 쿼리 예시 -->
+    <select id="findAnswerWithApplicationJobtestId" resultMap="AnswerWithFullMap" parameterType="int">
+        SELECT a.id                            as a_id,
+               a.content                       as a_content,
+               a.attempt                       as a_attempt,
+               a.is_correct                    as a_is_correct,
+               a.score                         as a_score,
+               a.application_job_test_id       as a_application_job_test_id,
+               a.question_id                   as a_question_id,
+
+               jq.score                        as jq_score,
+
+               q.id                            as q_id,
+               q.content                       as q_content,
+               q.detail_content                as q_detail_content,
+               q.type                          as q_type,
+               q.difficulty                    as q_difficulty,
+               q.answer                        as q_answer,
+
+               qo.id                           as qo_id,
+               qo.option_number                as qo_option_number,
+               qo.content                      as qo_content,
+
+               gc.id                           as gc_id,
+               gc.content                      as gc_content,
+               gc.score_weight                 as gc_score_weight,
+
+               gr.id                           as gr_id,
+               gr.question_grading_criteria_id as gr_grading_criteria_id,
+               gr.is_satisfied                 as gr_is_satisfied,
+               gr.answer_id                    as gr_answer_id
+
+        FROM answer a
+                 LEFT JOIN question q ON a.question_id = q.id
+                 LEFT JOIN question_option qo ON qo.question_id = q.id
+                 LEFT JOIN question_grading_criteria gc ON gc.question_id = q.id
+                 LEFT JOIN grading_result gr ON gr.answer_id = a.id
+                 LEFT JOIN application_job_test ajt ON ajt.id = a.application_job_test_id
+                 LEFT JOIN job_test_question jq ON jq.question_id = a.question_id AND jq.job_test_id = ajt.job_test_id
+        WHERE a.application_job_test_id = #{applicationJobtestId}
+    </select>
+
+</mapper>


### PR DESCRIPTION
### 🪄 PR 타입
- [X] 신규 기능
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] 버그 픽스

### #️⃣ 연관된 이슈
close #이슈번호


### 📝 변경 사항
특정 지원서별 실무테스트의 답안 & 채점 상태 & 문제 정보 등 한번에 조회하는 쿼리 구현


### 📷 관련 스크린샷
![{1FF7A9B7-5EE3-42C8-9DF7-41AE30B3C2A3}](https://github.com/user-attachments/assets/7c445e88-f1fb-4e0a-a90f-3498cb72b1ae)


### 🧪 테스트 계획   또는 완료 사항
- [ ] 실무테스트 답안 조회 : [GET] /api/v1/employment/answers/{applicationJobtestId}