### PR TITLE
[feat] 면접평가표id로 해당 평가표에 들어 있는 평가 기준 조회 기능 구현

### DIFF
--- a/src/main/java/com/piveguyz/empickbackend/employment/interviews/interviewCriteria/query/controller/InterviewCriteriaQueryController.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/interviews/interviewCriteria/query/controller/InterviewCriteriaQueryController.java
@@ -78,4 +78,22 @@ public class InterviewCriteriaQueryController {
         return ResponseEntity.status(result.getHttpStatus())
                 .body(CustomApiResponse.of(result, dtoList));
     }
+
+    @Operation(
+            summary = "면접 평가표 id로 면접 평가 기준 검색",
+            description = """
+    - 면접 평가표 id로 면접 평가 기준을 검색합니다.
+    """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "요청이 성공적으로 처리되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다.")
+    })
+    @GetMapping("/sheet/{sheetId}")
+    public ResponseEntity<CustomApiResponse<List<InterviewCriteriaQueryDTO>>> findBySheetId(@PathVariable("sheetId") Integer sheetId) {
+        List<InterviewCriteriaQueryDTO> dtoList = service.findBySheetId(sheetId);
+        ResponseCode result = ResponseCode.SUCCESS;
+        return ResponseEntity.status(result.getHttpStatus())
+                .body(CustomApiResponse.of(result, dtoList));
+    }
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/interviews/interviewCriteria/query/mapper/InterviewCriteriaMapper.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/interviews/interviewCriteria/query/mapper/InterviewCriteriaMapper.java
@@ -12,4 +12,6 @@ public interface InterviewCriteriaMapper {
     InterviewCriteriaQueryDTO findById(Integer id);
 
     List<InterviewCriteriaQueryDTO> searchByTitle(String title);
+
+    List<InterviewCriteriaQueryDTO> findBySheetId(Integer sheetId);
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/interviews/interviewCriteria/query/service/InterviewCriteriaQueryService.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/interviews/interviewCriteria/query/service/InterviewCriteriaQueryService.java
@@ -10,4 +10,6 @@ public interface InterviewCriteriaQueryService {
     InterviewCriteriaQueryDTO findById(Integer id);
 
     List<InterviewCriteriaQueryDTO> searchByTitle(String title);
+
+    List<InterviewCriteriaQueryDTO> findBySheetId(Integer sheetId);
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/interviews/interviewCriteria/query/service/InterviewCriteriaQueryServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/interviews/interviewCriteria/query/service/InterviewCriteriaQueryServiceImpl.java
@@ -36,4 +36,10 @@ public class InterviewCriteriaQueryServiceImpl implements InterviewCriteriaQuery
         List<InterviewCriteriaQueryDTO> dtoList = mapper.searchByTitle(title);
         return dtoList;
     }
+
+    @Override
+    public List<InterviewCriteriaQueryDTO> findBySheetId(Integer sheetId) {
+        List<InterviewCriteriaQueryDTO> dtoList = mapper.findBySheetId(sheetId);
+        return dtoList;
+    }
 }

--- a/src/main/resources/mapper/interviewCriteria/InterviewCriteriaMapper.xml
+++ b/src/main/resources/mapper/interviewCriteria/InterviewCriteriaMapper.xml
@@ -59,4 +59,19 @@
           AND is_deleted = 'N';
     </select>
 
+    <select id="findBySheetId" resultMap="InterviewCriteriaResultMap">
+        SELECT
+            id,
+            sheet_id,
+            title,
+            content,
+            weight,
+            is_deleted,
+            member_id,
+            updated_at
+        FROM interview_criteria
+        WHERE sheet_id = #{sheetId}
+          AND is_deleted = 'N';
+    </select>
+
 </mapper>

--- a/src/main/resources/schema/tables/interview.sql
+++ b/src/main/resources/schema/tables/interview.sql
@@ -2,8 +2,8 @@ SET foreign_key_checks = 0;
 
 DROP TABLE IF EXISTS `interview_sheet`;
 DROP TABLE IF EXISTS `interview_criteria`;
-DROP TABLE IF EXISTS `interview_sheet_item`;
 DROP TABLE IF EXISTS `interview`;
+DROP TABLE IF EXISTS `interviewer`;
 DROP TABLE IF EXISTS `interview_score`;
 
 SET foreign_key_checks = 1;
@@ -32,18 +32,6 @@ CREATE TABLE `interview_criteria` (
 )
 COMMENT = '면접 평가표 기준';
 
-# CREATE TABLE `interview_sheet_item` (
-#     `id`	INT	NOT NULL PRIMARY KEY AUTO_INCREMENT COMMENT 'id',
-#     `sheet_id`	INT	NOT NULL COMMENT '평가표 id',
-#     `criteria_id`	INT	NOT NULL COMMENT '면접 평가 기준 id',
-#     `weight`	DOUBLE	NOT NULL COMMENT '가중치',
-#     `member_id`	INT NULL COMMENT '수정자 id',
-#     `updated_at`	DATETIME NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '수정 일시',
-#     FOREIGN KEY (`sheet_id`) REFERENCES `interview_sheet`(`id`),
-#     FOREIGN KEY (`criteria_id`) REFERENCES `interview_criteria`(`id`),
-#     FOREIGN KEY (`member_id`) REFERENCES `member`(`id`)
-# )
-# COMMENT = '평가 기준표별 평가 기준';
 
 CREATE TABLE `interview` (
      `id`	INT	NOT NULL PRIMARY KEY AUTO_INCREMENT COMMENT 'id',


### PR DESCRIPTION
### 🪄 PR 타입
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] 버그 픽스

### #️⃣ 연관된 이슈
#64 


### 📝 변경 사항
면접평가표id로 해당 평가표에 들어 있는 평가 기준 조회 기능 구현


----

아래 내용은 없을 경우 삭제하면 됩니다.

### 🐛 어떤 위험이나 장애가 발견되었는지 (버그 픽스인 경우)


### 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분


### 📷 관련 스크린샷


### 🧪 테스트 계획 또는 완료 사항
- [ ] 면접평가표id로 평가기준들 조회
[GET] localhost:5001/api/v1/employment/interview-criteria/sheet/{id}
id = 2000, 2001로 조회하면 확인 가능
