### PR TITLE
[feat] 실무테스트 입장 검증 구현

### DIFF
--- a/src/main/java/com/piveguyz/empickbackend/common/response/ResponseCode.java
+++ b/src/main/java/com/piveguyz/empickbackend/common/response/ResponseCode.java
@@ -180,8 +180,9 @@ public enum ResponseCode {
     //   3) 지원서별 실무테스트
     EMPLOYMENT_INVALID_ENTRY_CODE(false, HttpStatus.BAD_REQUEST, 2300, "입장 코드는 5자리 숫자여야 합니다."),
     EMPLOYMENT_ENTRY_CODE_DUPLICATE(false, HttpStatus.CONFLICT, 2301, "중복된 입장 코드입니다."),
-    EMPLOYMENT_INVALID_APPLICATION_JOBTEST(false, HttpStatus.NOT_FOUND, 2302, "존재하지 않는 지원서별 실무테스트입니다."),
-
+    EMPLOYMENT_JOBTEST_INVALID_ENTRY_CODE(false, HttpStatus.NOT_FOUND, 2302, "입장 코드가 올바르지 않습니다."),
+    EMPLOYMENT_INVALID_APPLICATION_JOBTEST(false, HttpStatus.NOT_FOUND, 2303, "존재하지 않는 지원서별 실무테스트입니다."),
+    EMPLOYMENT_INVALID_TIME(false, HttpStatus.BAD_REQUEST, 2304, "시험 시간이 아닙니다."),
 
     //   4) 실무테스트 답안
     EMPLOYMENT_INVALID_JOBTEST_ANSWER(false, HttpStatus.NOT_FOUND,2440, "요청한 답안을 찾을 수 없습니다."),

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/application/controller/ApplicationJobtestCommandController.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/application/controller/ApplicationJobtestCommandController.java
@@ -3,25 +3,29 @@ package com.piveguyz.empickbackend.employment.jobtests.jobtest.command.applicati
 import com.piveguyz.empickbackend.common.response.CustomApiResponse;
 import com.piveguyz.empickbackend.common.response.ResponseCode;
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.application.dto.CreateApplicationJobtestCommandDTO;
+import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.application.dto.JobtestEntryRequestDTO;
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.application.dto.UpdateApplicationJobtestCommandDTO;
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.application.service.ApplicationJobtestCommandService;
+import com.piveguyz.empickbackend.facade.JobtestFacade;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @Tag(name = "실무테스트 API", description = "실무테스트 관련 API")
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/v1/employment/application-jobtests")
 public class ApplicationJobtestCommandController {
 
     private final ApplicationJobtestCommandService applicationJobtestCommandService;
+    private final JobtestFacade jobtestFacade;
 
-    public ApplicationJobtestCommandController(ApplicationJobtestCommandService applicationJobtestCommandService) {
-        this.applicationJobtestCommandService = applicationJobtestCommandService;
-    }
 
     @Operation(
             summary = "지원서별 실무테스트 등록",
@@ -70,5 +74,24 @@ public class ApplicationJobtestCommandController {
         int deleteId = applicationJobtestCommandService.deleteApplicationJobtest(id);
         return ResponseEntity.status(ResponseCode.SUCCESS.getHttpStatus())
                 .body((CustomApiResponse.of(ResponseCode.SUCCESS, deleteId)));
+    }
+
+
+    @Operation(
+            summary = "실무테스트 입장",
+            description = """
+                    실무테스트 입장 검증
+                    """
+    )
+    @ApiResponses(value = {
+    })
+    @PostMapping("/enter/{jobtestId}")
+    public ResponseEntity<CustomApiResponse<String>> verifyEntry(
+            @PathVariable int jobtestId,
+            @RequestBody JobtestEntryRequestDTO request
+    ) {
+        jobtestFacade.verifyJobtestEnter(jobtestId, request);
+        return ResponseEntity.status(ResponseCode.SUCCESS.getHttpStatus())
+                .body((CustomApiResponse.of(ResponseCode.SUCCESS, ResponseCode.SUCCESS.getMessage())));
     }
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/application/dto/CreateApplicationJobtestCommandDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/application/dto/CreateApplicationJobtestCommandDTO.java
@@ -21,5 +21,6 @@ public class CreateApplicationJobtestCommandDTO {
 
     private int applicationId;
     private int jobtestId;
-    private Integer memberId;
+    private Integer gradingMemberId;
+    private Integer evaluationMemberId;
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/application/dto/JobtestEntryRequestDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/application/dto/JobtestEntryRequestDTO.java
@@ -1,0 +1,13 @@
+package com.piveguyz.empickbackend.employment.jobtests.jobtest.command.application.dto;
+
+import lombok.*;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class JobtestEntryRequestDTO {
+    private String entryCode;
+
+}

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/application/dto/UpdateApplicationJobtestCommandDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/application/dto/UpdateApplicationJobtestCommandDTO.java
@@ -19,5 +19,6 @@ public class UpdateApplicationJobtestCommandDTO {
     private JobtestStatus evaluationStatus;
     private String entryCode;
 
-    private Integer memberId;
+    private Integer evaluationMemberId;
+    private Integer gradingMemberId;
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/application/mapper/ApplicationJobtestMapper.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/application/mapper/ApplicationJobtestMapper.java
@@ -17,7 +17,8 @@ public class ApplicationJobtestMapper {
                 .entryCode(dto.getEntryCode())
                 .applicationId(dto.getApplicationId())
                 .jobTestId(dto.getJobtestId())
-                .memberId(dto.getMemberId())
+                .gradingMemberId(dto.getGradingMemberId())
+                .evaluationMemberId(dto.getEvaluationMemberId())
                 .build();
     }
 
@@ -33,7 +34,8 @@ public class ApplicationJobtestMapper {
                 .entryCode(entity.getEntryCode())
                 .applicationId(entity.getApplicationId())
                 .jobtestId(entity.getJobTestId())
-                .memberId(entity.getMemberId())
+                .gradingMemberId(entity.getGradingMemberId())
+                .evaluationMemberId(entity.getEvaluationMemberId())
                 .build();
     }
 
@@ -46,7 +48,8 @@ public class ApplicationJobtestMapper {
                 .gradingStatus(entity.getGradingStatus())
                 .evaluationStatus(entity.getEvaluationStatus())
                 .entryCode(entity.getEntryCode())
-                .memberId(entity.getMemberId())
+                .gradingMemberId(entity.getGradingMemberId())
+                .evaluationMemberId(entity.getEvaluationMemberId())
                 .build();
     }
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/application/service/ApplicationJobtestCommandService.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/application/service/ApplicationJobtestCommandService.java
@@ -1,6 +1,7 @@
 package com.piveguyz.empickbackend.employment.jobtests.jobtest.command.application.service;
 
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.application.dto.CreateApplicationJobtestCommandDTO;
+import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.application.dto.JobtestEntryRequestDTO;
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.application.dto.UpdateApplicationJobtestCommandDTO;
 import jakarta.validation.Valid;
 
@@ -12,4 +13,6 @@ public interface ApplicationJobtestCommandService {
     int deleteApplicationJobtest(int id);
 
     void updateGradingStatusAndScore(int applicationJobTestId, double totalScore);
+
+    void verifyEntryCode(int jobtestId, JobtestEntryRequestDTO requestDTO);
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/application/service/ApplicationJobtestCommandServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/application/service/ApplicationJobtestCommandServiceImpl.java
@@ -4,14 +4,20 @@ import com.piveguyz.empickbackend.common.exception.BusinessException;
 import com.piveguyz.empickbackend.common.response.ResponseCode;
 import com.piveguyz.empickbackend.employment.applicant.command.domain.repository.ApplicationRepository;
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.application.dto.CreateApplicationJobtestCommandDTO;
+import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.application.dto.JobtestEntryRequestDTO;
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.application.dto.UpdateApplicationJobtestCommandDTO;
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.application.mapper.ApplicationJobtestMapper;
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.domain.aggregate.ApplicationJobtestEntity;
+import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.domain.aggregate.JobtestEntity;
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.domain.repository.ApplicationJobtestRepository;
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.domain.repository.JobtestRepository;
 import com.piveguyz.empickbackend.orgstructure.member.command.domain.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -38,7 +44,7 @@ public class ApplicationJobtestCommandServiceImpl implements ApplicationJobtestC
         validateEntryCode(createApplicationJobtestCommandDTO.getEntryCode());
 
         // 평가자가 값이 들어왔는데 평가자가 member에 없는 경우
-        validateMemberExists(createApplicationJobtestCommandDTO.getMemberId());
+        validateMemberExists(createApplicationJobtestCommandDTO.getEvaluationMemberId());
 
         ApplicationJobtestEntity applicationJobtestEntity = ApplicationJobtestMapper.toEntity(createApplicationJobtestCommandDTO);
         ApplicationJobtestEntity saved = applicationJobtestRepository.save(applicationJobtestEntity);
@@ -56,7 +62,7 @@ public class ApplicationJobtestCommandServiceImpl implements ApplicationJobtestC
         validateEntryCode(updateApplicationJobtestCommandDTO.getEntryCode());
 
         // 평가자를 수정할건데 member에 없는 경우
-        validateMemberExists(updateApplicationJobtestCommandDTO.getMemberId());
+        validateMemberExists(updateApplicationJobtestCommandDTO.getEvaluationMemberId());
 
         applicationJobtest.updateApplicationJobtestEntity(updateApplicationJobtestCommandDTO);
         ApplicationJobtestEntity updatedEntity = applicationJobtestRepository.save(applicationJobtest);
@@ -80,6 +86,23 @@ public class ApplicationJobtestCommandServiceImpl implements ApplicationJobtestC
 
         applicationJobtest.completeGrading(totalScore);
         applicationJobtestRepository.save(applicationJobtest);
+    }
+
+    @Override
+    public void verifyEntryCode(int jobtestId, JobtestEntryRequestDTO requestDTO) {
+        List<ApplicationJobtestEntity> applicationJobtest = applicationJobtestRepository.findByJobTestId(jobtestId);
+
+        boolean flag = false;
+        for(ApplicationJobtestEntity applicationJobtestEntity : applicationJobtest) {
+            if(applicationJobtestEntity.getEntryCode().equals(requestDTO.getEntryCode())) {
+                flag = true;
+                break;
+            }
+        }
+        if(!flag) {
+            throw new BusinessException(ResponseCode.EMPLOYMENT_JOBTEST_INVALID_ENTRY_CODE);
+        }
+
     }
 
 

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/application/service/JobtestCommandService.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/application/service/JobtestCommandService.java
@@ -15,4 +15,6 @@ public interface JobtestCommandService {
     Integer deleteJobtest(int id);
 
     Optional<JobtestEntity> findById(int jobtestId);
+
+    void checkJobtestTime(int jobtestId);
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/application/service/JobtestCommandServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/application/service/JobtestCommandServiceImpl.java
@@ -11,7 +11,10 @@ import com.piveguyz.empickbackend.orgstructure.member.command.domain.repository.
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
+
+import static org.springframework.data.jpa.domain.AbstractPersistable_.id;
 
 @Service
 public class JobtestCommandServiceImpl implements JobtestCommandService {
@@ -79,5 +82,15 @@ public class JobtestCommandServiceImpl implements JobtestCommandService {
     @Override
     public Optional<JobtestEntity> findById(int jobtestId) {
         return jobtestRepository.findById(jobtestId);
+    }
+
+    @Override
+    public void checkJobtestTime(int jobtestId) {
+        LocalDateTime now = LocalDateTime.now();
+        JobtestEntity jobtest = jobtestRepository.findById(jobtestId)
+                .orElseThrow(() -> new BusinessException(ResponseCode.EMPLOYMENT_INVALID_JOBTEST));
+        if(now.isBefore(jobtest.getStartedAt()) || now.isAfter(jobtest.getEndedAt())) {
+            throw new BusinessException(ResponseCode.EMPLOYMENT_INVALID_TIME);
+        }
     }
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/domain/aggregate/ApplicationJobtestEntity.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/domain/aggregate/ApplicationJobtestEntity.java
@@ -49,8 +49,11 @@ public class ApplicationJobtestEntity {
     @Column(name = "job_test_id", nullable = false)
     private int jobTestId;
 
-    @Column(name = "member_id", nullable = true)
-    private Integer memberId;
+    @Column(name = "evaluation_member_id", nullable = true)
+    private Integer evaluationMemberId;
+
+    @Column(name = "grading_member_id", nullable = true)
+    private Integer gradingMemberId;
 
 
     public void updateApplicationJobtestEntity(UpdateApplicationJobtestCommandDTO updateApplicationJobtestCommandDTO) {
@@ -75,8 +78,11 @@ public class ApplicationJobtestEntity {
         if(updateApplicationJobtestCommandDTO.getEntryCode() != null) {
             this.entryCode = updateApplicationJobtestCommandDTO.getEntryCode();
         }
-        if(updateApplicationJobtestCommandDTO.getMemberId() != null) {
-            this.memberId = updateApplicationJobtestCommandDTO.getMemberId();
+        if(updateApplicationJobtestCommandDTO.getEvaluationMemberId() != null) {
+            this.evaluationMemberId = updateApplicationJobtestCommandDTO.getEvaluationMemberId();
+        }
+        if(updateApplicationJobtestCommandDTO.getGradingMemberId() != null) {
+            this.gradingMemberId = updateApplicationJobtestCommandDTO.getGradingMemberId();
         }
 
     }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/domain/repository/ApplicationJobtestRepository.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/domain/repository/ApplicationJobtestRepository.java
@@ -4,7 +4,12 @@ import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.domain.agg
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
 public interface ApplicationJobtestRepository extends JpaRepository<ApplicationJobtestEntity, Integer> {
     boolean existsByEntryCode(String entryCode);
+
+    List<ApplicationJobtestEntity> findByJobTestId(int jobtestId);
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/query/dto/ApplicationInfoDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/query/dto/ApplicationInfoDTO.java
@@ -21,5 +21,5 @@ public class ApplicationInfoDTO {
     private String evaluationMemberName;
 
     private int applicationJobtestId;
-    private int entryCode;
+    private String entryCode;
 }

--- a/src/main/java/com/piveguyz/empickbackend/facade/JobtestFacade.java
+++ b/src/main/java/com/piveguyz/empickbackend/facade/JobtestFacade.java
@@ -5,20 +5,19 @@ import com.piveguyz.empickbackend.common.response.ResponseCode;
 import com.piveguyz.empickbackend.employment.jobtests.answer.command.application.dto.UpdateAnswerCommandDTO;
 import com.piveguyz.empickbackend.employment.jobtests.answer.command.application.service.AnswerCommandService;
 import com.piveguyz.empickbackend.employment.jobtests.answer.command.domain.aggregate.AnswerEntity;
-import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.application.dto.CreateJobtestCommandDTO;
-import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.application.dto.CreateJobtestQuestionCommandDTO;
-import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.application.dto.CreateJobtestQuestionResponseDTO;
-import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.application.dto.CreateJobtestResponseDTO;
+import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.application.dto.*;
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.application.mapper.JobtestMapper;
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.application.service.ApplicationJobtestCommandService;
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.application.service.JobtestCommandService;
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.application.service.JobtestQuestionCommandService;
+import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.domain.aggregate.ApplicationJobtestEntity;
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.domain.aggregate.JobtestEntity;
 import com.piveguyz.empickbackend.employment.jobtests.question.command.application.service.QuestionCommandService;
 import com.piveguyz.empickbackend.employment.jobtests.question.command.domain.aggregate.QuestionEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -79,5 +78,14 @@ public class JobtestFacade {
         applicationJobtestCommandService.updateGradingStatusAndScore(applicationJobTestId, totalScore);
 
         return updateAnswers;
+    }
+
+    public void verifyJobtestEnter(int jobtestId, JobtestEntryRequestDTO requestDTO) {
+        // 유효한 코드인지 확인
+        applicationJobtestCommandService.verifyEntryCode(jobtestId, requestDTO);
+
+
+        // 시험시간인지 확인
+        jobtestCommandService.checkJobtestTime(jobtestId);
     }
 }

--- a/src/main/resources/mapper/jobtest/JobtestMapper.xml
+++ b/src/main/resources/mapper/jobtest/JobtestMapper.xml
@@ -59,7 +59,6 @@
         <result property="evaluationMemberName" column="e_member_name"/>
 
         <result property="applicationJobtestId" column="ajt_id"/>
-        <result property="entryCode" column="entry_code"/>
     </resultMap>
 
     <resultMap id="JobTestApplicationsMap"
@@ -139,7 +138,6 @@
                ajt.id                  AS ajt_id,
                ajt.grading_status      AS g_status,
                ajt.grading_total_score AS g_score,
-               ajt.entry_code,
                gm.name                 AS g_member_name,
 
                ajt.evaluation_status   AS e_status,


### PR DESCRIPTION
### 🪄 PR 타입
- [X] 신규 기능
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] 버그 픽스

### #️⃣ 연관된 이슈
close #이슈번호


### 📝 변경 사항
- 실무테스트 입장 시 코드가 부합한지 확인합니다.
- 실무테스트 입장 시 현재 시간이 실무테스트 시간인지 확인합니다.


----


### 📷 관련 스크린샷
 - 입장 성공
![{4E9A59A9-7523-43F1-B977-7C4CEE33948F}](https://github.com/user-attachments/assets/b83a7d07-35e4-44e6-acbe-bb9a6153112e)

- 입장 코드가 틀렸을 때
![{5787C7E9-2A1C-43AD-9D86-2DCE2EEA51FA}](https://github.com/user-attachments/assets/27739041-4801-4df2-8e8c-7b8fb9da3620)

- 시험 시간이 아닐 때
![{039CCF9B-7349-428D-A9FD-EA020D353B6E}](https://github.com/user-attachments/assets/e88524f7-f9bc-47d2-9b19-58dc1eecd0d0)


### 🧪 테스트 계획 또는 완료 사항
- [ ] 실무테스트 입장 검증 : [POST] /api/v1/employment/application-jobtests/enter/{jobtestId}
