### PR TITLE
[refactor] 실무테스트 할당 기능 수정

### DIFF
--- a/src/main/java/com/piveguyz/empickbackend/common/response/ResponseCode.java
+++ b/src/main/java/com/piveguyz/empickbackend/common/response/ResponseCode.java
@@ -181,7 +181,7 @@ public enum ResponseCode {
     EMPLOYMENT_INVALID_ENTRY_CODE(false, HttpStatus.BAD_REQUEST, 2300, "입장 코드는 5자리 숫자여야 합니다."),
     EMPLOYMENT_ENTRY_CODE_DUPLICATE(false, HttpStatus.CONFLICT, 2301, "중복된 입장 코드입니다."),
     EMPLOYMENT_INVALID_APPLICATION_JOBTEST(false, HttpStatus.NOT_FOUND, 2302, "존재하지 않는 지원서별 실무테스트입니다."),
-
+    EMPLOYMENT_APPLICATION_JOBTEST_ALREADY_EXISTS(false, HttpStatus.CONFLICT, 2303, "해당 지원서에 이미 실무테스트가 할당되어 있습니다."),
 
     //   4) 실무테스트 답안
     EMPLOYMENT_INVALID_JOBTEST_ANSWER(false, HttpStatus.NOT_FOUND,2440, "요청한 답안을 찾을 수 없습니다."),

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/application/dto/CreateApplicationJobtestCommandDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/application/dto/CreateApplicationJobtestCommandDTO.java
@@ -21,5 +21,4 @@ public class CreateApplicationJobtestCommandDTO {
 
     private int applicationId;
     private int jobtestId;
-    private Integer memberId;
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/application/dto/UpdateApplicationJobtestCommandDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/application/dto/UpdateApplicationJobtestCommandDTO.java
@@ -19,5 +19,6 @@ public class UpdateApplicationJobtestCommandDTO {
     private JobtestStatus evaluationStatus;
     private String entryCode;
 
-    private Integer memberId;
+    private Integer gradingMemberId;
+    private Integer evaluationMemberId;
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/application/mapper/ApplicationJobtestMapper.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/application/mapper/ApplicationJobtestMapper.java
@@ -3,21 +3,20 @@ package com.piveguyz.empickbackend.employment.jobtests.jobtest.command.applicati
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.application.dto.CreateApplicationJobtestCommandDTO;
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.application.dto.UpdateApplicationJobtestCommandDTO;
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.domain.aggregate.ApplicationJobtestEntity;
+import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.domain.aggregate.enums.JobtestStatus;
 
 public class ApplicationJobtestMapper {
 
     public static ApplicationJobtestEntity toEntity(CreateApplicationJobtestCommandDTO dto) {
         return ApplicationJobtestEntity.builder()
                 .evaluatorComment(dto.getEvaluatorComment())
-                .submittedAt(dto.getSubmittedAt())
-                .gradingTotalScore(dto.getGradingTotalScore())
-                .evaluationScore(dto.getEvaluationScore())
-                .evaluationStatus(dto.getEvaluationStatus())
-                .gradingStatus(dto.getGradingStatus())
+                .gradingTotalScore(0.0)
+                .evaluationScore(0.0)
+                .evaluationStatus(JobtestStatus.WAITING)
+                .gradingStatus(JobtestStatus.WAITING)
                 .entryCode(dto.getEntryCode())
                 .applicationId(dto.getApplicationId())
                 .jobTestId(dto.getJobtestId())
-                .memberId(dto.getMemberId())
                 .build();
     }
 
@@ -33,7 +32,6 @@ public class ApplicationJobtestMapper {
                 .entryCode(entity.getEntryCode())
                 .applicationId(entity.getApplicationId())
                 .jobtestId(entity.getJobTestId())
-                .memberId(entity.getMemberId())
                 .build();
     }
 
@@ -46,7 +44,8 @@ public class ApplicationJobtestMapper {
                 .gradingStatus(entity.getGradingStatus())
                 .evaluationStatus(entity.getEvaluationStatus())
                 .entryCode(entity.getEntryCode())
-                .memberId(entity.getMemberId())
+                .gradingMemberId(entity.getGradingMemberId())
+                .evaluationMemberId(entity.getEvaluationMemberId())
                 .build();
     }
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/application/service/ApplicationJobtestCommandServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/application/service/ApplicationJobtestCommandServiceImpl.java
@@ -37,8 +37,11 @@ public class ApplicationJobtestCommandServiceImpl implements ApplicationJobtestC
         // 유효하지 않은 입장 코드인경우
         validateEntryCode(createApplicationJobtestCommandDTO.getEntryCode());
 
-        // 평가자가 값이 들어왔는데 평가자가 member에 없는 경우
-        validateMemberExists(createApplicationJobtestCommandDTO.getMemberId());
+        // 이미 할당된 지원서인경우
+        if(applicationJobtestRepository.existsByApplicationId(createApplicationJobtestCommandDTO.getApplicationId())) {
+            throw new BusinessException(ResponseCode.EMPLOYMENT_APPLICATION_JOBTEST_ALREADY_EXISTS);
+        }
+
 
         ApplicationJobtestEntity applicationJobtestEntity = ApplicationJobtestMapper.toEntity(createApplicationJobtestCommandDTO);
         ApplicationJobtestEntity saved = applicationJobtestRepository.save(applicationJobtestEntity);
@@ -55,8 +58,11 @@ public class ApplicationJobtestCommandServiceImpl implements ApplicationJobtestC
         // 유효하지 않은 입장 코드인 경우
         validateEntryCode(updateApplicationJobtestCommandDTO.getEntryCode());
 
+        // 채점자를 수정할건데 member에 없는 경우
+        validateMemberExists(updateApplicationJobtestCommandDTO.getGradingMemberId());
+
         // 평가자를 수정할건데 member에 없는 경우
-        validateMemberExists(updateApplicationJobtestCommandDTO.getMemberId());
+        validateMemberExists(updateApplicationJobtestCommandDTO.getEvaluationMemberId());
 
         applicationJobtest.updateApplicationJobtestEntity(updateApplicationJobtestCommandDTO);
         ApplicationJobtestEntity updatedEntity = applicationJobtestRepository.save(applicationJobtest);
@@ -91,10 +97,10 @@ public class ApplicationJobtestCommandServiceImpl implements ApplicationJobtestC
 
     private void validateEntryCode(String entryCode) {
         if (entryCode != null) {
-            // 5자리 숫자가 아닌 경우
-            if (!entryCode.matches("^\\d{5}$")) {
-                throw new BusinessException(ResponseCode.EMPLOYMENT_INVALID_ENTRY_CODE);
-            }
+//            // 5자리 숫자가 아닌 경우
+//            if (!entryCode.matches("^\\d{5}$")) {
+//                throw new BusinessException(ResponseCode.EMPLOYMENT_INVALID_ENTRY_CODE);
+//            }
 
             // 중복된 경우
             if (applicationJobtestRepository.existsByEntryCode(entryCode)) {

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/domain/aggregate/ApplicationJobtestEntity.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/domain/aggregate/ApplicationJobtestEntity.java
@@ -20,16 +20,16 @@ public class ApplicationJobtestEntity {
     @Column(name = "id")
     private int id;
 
-    @Column(name = "evaluator_comment", nullable = false)
+    @Column(name = "evaluator_comment", nullable = true)
     private String evaluatorComment;
 
     @Column(name = "submitted_at", nullable = true)
     private LocalDateTime submittedAt;
 
-    @Column(name = "grading_total_score", nullable = true)
+    @Column(name = "grading_total_score", nullable = false)
     private Double gradingTotalScore;
 
-    @Column(name = "evaluation_score", nullable = true)
+    @Column(name = "evaluation_score", nullable = false)
     private Double evaluationScore;
 
     @Enumerated(EnumType.ORDINAL)
@@ -49,8 +49,11 @@ public class ApplicationJobtestEntity {
     @Column(name = "job_test_id", nullable = false)
     private int jobTestId;
 
-    @Column(name = "member_id", nullable = true)
-    private Integer memberId;
+    @Column(name = "grading_member_id", nullable = true)
+    private Integer gradingMemberId;
+
+    @Column(name = "evaluation_member_id", nullable = true)
+    private Integer evaluationMemberId;
 
 
     public void updateApplicationJobtestEntity(UpdateApplicationJobtestCommandDTO updateApplicationJobtestCommandDTO) {
@@ -75,8 +78,11 @@ public class ApplicationJobtestEntity {
         if(updateApplicationJobtestCommandDTO.getEntryCode() != null) {
             this.entryCode = updateApplicationJobtestCommandDTO.getEntryCode();
         }
-        if(updateApplicationJobtestCommandDTO.getMemberId() != null) {
-            this.memberId = updateApplicationJobtestCommandDTO.getMemberId();
+        if(updateApplicationJobtestCommandDTO.getGradingMemberId() != null) {
+            this.gradingMemberId = updateApplicationJobtestCommandDTO.getGradingMemberId();
+        }
+        if(updateApplicationJobtestCommandDTO.getEvaluationMemberId() != null) {
+            this.evaluationMemberId = updateApplicationJobtestCommandDTO.getEvaluationMemberId();
         }
 
     }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/domain/repository/ApplicationJobtestRepository.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/domain/repository/ApplicationJobtestRepository.java
@@ -7,4 +7,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ApplicationJobtestRepository extends JpaRepository<ApplicationJobtestEntity, Integer> {
     boolean existsByEntryCode(String entryCode);
+
+    boolean existsByApplicationId(int applicationId);
 }

--- a/src/main/resources/schema/tables/job_test.sql
+++ b/src/main/resources/schema/tables/job_test.sql
@@ -37,7 +37,7 @@ CREATE TABLE application_job_test
 (
     id                   INT          NOT NULL AUTO_INCREMENT PRIMARY KEY,
     evaluator_comment    LONGTEXT     NULL COMMENT '평가자 코멘트',
-    submitted_at         DATETIME     NOT NULL COMMENT '제출 일시',
+    submitted_at         DATETIME     NULL COMMENT '제출 일시',
     grading_total_score  DOUBLE       NOT NULL DEFAULT 0.0 COMMENT '채점 총 점수',
     evaluation_score     DOUBLE       NOT NULL DEFAULT 0.0 COMMENT '평가 점수',
     grading_status       TINYINT      NOT NULL DEFAULT 0 COMMENT '채점 상태',


### PR DESCRIPTION
### 🪄 PR 타입
- [ ] 신규 기능
- [ ] 기능 수정
- [X] 리팩토링
- [ ] 버그 픽스

### #️⃣ 연관된 이슈
close #이슈번호


### 📝 변경 사항
- 실무테스트에 이미 할당되어 있는 경우 오류 메세지 추가
- 평가자만 있던 sql문 채점자도 추가(sql문 변경)
- requst에 맞춰서 entity, dto 수정

### 💭 참고 사항
- 프론트의 PR과 함께 테스트하면 더 쉽게 확인할 수 있습니다.

### 🧪 테스트 계획 또는 완료 사항
- 이미 할당되어 있는 경우
![{FDAEE0B5-8109-4A50-BE3F-8D4A8204576D}](https://github.com/user-attachments/assets/ad5d44ed-1d91-4ce1-a5eb-fa140e50c364)

- 할당 성공
![{747BE57B-DFCC-4FCB-8155-726D67C7AD49}](https://github.com/user-attachments/assets/3109420c-c3d6-49de-a68d-64c5fc6c6c12)
