### PR TITLE
[feat] 결재 등록 기능 구현

### DIFF
--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/application/controller/ApprovalCommandController.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/application/controller/ApprovalCommandController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "결재 API", description = "결재 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/approvals")
+@RequestMapping("/api/v1/approvals")
 public class ApprovalCommandController {
 
     private final ApprovalCommandService approvalCommandService;

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/application/controller/ApprovalCommandController.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/application/controller/ApprovalCommandController.java
@@ -1,0 +1,39 @@
+package com.piveguyz.empickbackend.approvals.approval.command.application.controller;
+
+import com.piveguyz.empickbackend.approvals.approval.command.application.dto.CreateApprovalCommandDTO;
+import com.piveguyz.empickbackend.approvals.approval.command.application.service.ApprovalCommandService;
+import com.piveguyz.empickbackend.common.response.CustomApiResponse;
+import com.piveguyz.empickbackend.common.response.ResponseCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "결재 API", description = "결재 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/approvals")
+public class ApprovalCommandController {
+
+    private final ApprovalCommandService approvalCommandService;
+
+    @Operation(
+            summary = "결재 문서 생성",
+            description = """
+                    결재 문서를 생성합니다.
+                    """
+    )
+    @ApiResponses(value = {
+    })
+    @PostMapping
+    public ResponseEntity<CustomApiResponse<Integer>> createApproval(@RequestBody CreateApprovalCommandDTO dto) {
+        Integer approvalId = approvalCommandService.createApproval(dto);
+        return ResponseEntity.status(ResponseCode.SUCCESS.getHttpStatus())
+                .body(CustomApiResponse.of(ResponseCode.SUCCESS, approvalId));
+    }
+}

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/application/dto/ApprovalCategoryItemDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/application/dto/ApprovalCategoryItemDTO.java
@@ -1,0 +1,13 @@
+package com.piveguyz.empickbackend.approvals.approval.command.application.dto;
+
+import lombok.*;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ApprovalCategoryItemDTO {
+    private Integer id;
+    private String name;
+}

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/application/dto/ApprovalCommandResponseDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/application/dto/ApprovalCommandResponseDTO.java
@@ -1,0 +1,26 @@
+package com.piveguyz.empickbackend.approvals.approval.command.application.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ApprovalCommandResponseDTO {
+    private Integer approvalId;
+    private String categoryName;
+    private String writerName;
+    private String status;
+    private LocalDateTime createdAt;
+    private List<ContentDTO> contents;
+
+    @Getter @Setter
+    public static class ContentDTO {
+        private String itemName;
+        private String content;
+    }
+}

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/application/dto/CreateApprovalCommandDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/application/dto/CreateApprovalCommandDTO.java
@@ -1,0 +1,28 @@
+package com.piveguyz.empickbackend.approvals.approval.command.application.dto;
+
+import lombok.*;
+import java.util.List;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CreateApprovalCommandDTO {
+    private Integer categoryId;
+    private Integer writerId;
+    private List<ApproverDTO> approvers; // max 4명까지
+    private List<ApprovalContentDTO> contents;
+
+    @Getter @Setter
+    public static class ApproverDTO {
+        private Integer order; // 1~4
+        private Integer memberId;
+    }
+
+    @Getter @Setter
+    public static class ApprovalContentDTO {
+        private Integer itemId;
+        private String content;
+    }
+}

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/application/service/ApprovalCommandService.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/application/service/ApprovalCommandService.java
@@ -1,0 +1,10 @@
+package com.piveguyz.empickbackend.approvals.approval.command.application.service;
+
+import com.piveguyz.empickbackend.approvals.approval.command.application.dto.ApprovalCommandResponseDTO;
+import com.piveguyz.empickbackend.approvals.approval.command.application.dto.CreateApprovalCommandDTO;
+
+import java.util.List;
+
+public interface ApprovalCommandService {
+    Integer createApproval(CreateApprovalCommandDTO dto);
+}

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/application/service/ApprovalCommandServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/application/service/ApprovalCommandServiceImpl.java
@@ -28,6 +28,14 @@ public class ApprovalCommandServiceImpl implements ApprovalCommandService {
         Map<Integer, Integer> approverMap = dto.getApprovers().stream()
                 .collect(Collectors.toMap(CreateApprovalCommandDTO.ApproverDTO::getOrder, CreateApprovalCommandDTO.ApproverDTO::getMemberId));
 
+        for (CreateApprovalCommandDTO.ApprovalContentDTO contentDTO : dto.getContents()) {
+            boolean valid = approvalCategoryItemRepository
+                    .existsByIdAndCategoryId(contentDTO.getItemId(), dto.getCategoryId());
+            if (!valid) {
+                throw new IllegalArgumentException("항목 ID " + contentDTO.getItemId() + "은 해당 결재 유형에 속하지 않습니다.");
+            }
+        }
+
         ApprovalEntity approval = ApprovalEntity.builder()
                 .categoryId(dto.getCategoryId())
                 .writerId(dto.getWriterId())

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/application/service/ApprovalCommandServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/application/service/ApprovalCommandServiceImpl.java
@@ -1,0 +1,54 @@
+package com.piveguyz.empickbackend.approvals.approval.command.application.service;
+
+import com.piveguyz.empickbackend.approvals.approval.command.application.dto.ApprovalCommandResponseDTO;
+import com.piveguyz.empickbackend.approvals.approval.command.application.dto.CreateApprovalCommandDTO;
+import com.piveguyz.empickbackend.approvals.approval.command.domain.aggregate.ApprovalContentEntity;
+import com.piveguyz.empickbackend.approvals.approval.command.domain.aggregate.ApprovalEntity;
+import com.piveguyz.empickbackend.approvals.approval.command.domain.repository.ApprovalCategoryItemRepository;
+import com.piveguyz.empickbackend.approvals.approval.command.domain.repository.ApprovalContentRepository;
+import com.piveguyz.empickbackend.approvals.approval.command.domain.repository.ApprovalRepository;
+import com.piveguyz.empickbackend.orgstructure.member.command.domain.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ApprovalCommandServiceImpl implements ApprovalCommandService {
+    private final MemberRepository memberRepository;
+    private final ApprovalRepository approvalRepository;
+    private final ApprovalCategoryItemRepository approvalCategoryItemRepository;
+    private final ApprovalContentRepository approvalContentRepository;
+
+    @Override
+    public Integer createApproval(CreateApprovalCommandDTO dto) {
+        Map<Integer, Integer> approverMap = dto.getApprovers().stream()
+                .collect(Collectors.toMap(CreateApprovalCommandDTO.ApproverDTO::getOrder, CreateApprovalCommandDTO.ApproverDTO::getMemberId));
+
+        ApprovalEntity approval = ApprovalEntity.builder()
+                .categoryId(dto.getCategoryId())
+                .writerId(dto.getWriterId())
+                .firstApproverId(approverMap.get(1))
+                .secondApproverId(approverMap.get(2))
+                .thirdApproverId(approverMap.get(3))
+                .fourthApproverId(approverMap.get(4))
+                .build();
+
+        approvalRepository.save(approval);
+
+        List<ApprovalContentEntity> contents = dto.getContents().stream()
+                .map(c -> ApprovalContentEntity.builder()
+                        .approvalId(approval.getId())
+                        .itemId(c.getItemId())
+                        .content(c.getContent())
+                        .build()
+                ).toList();
+
+        approvalContentRepository.saveAll(contents);
+
+        return approval.getId();
+    }
+}

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/domain/aggregate/ApprovalCategoryEntity.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/domain/aggregate/ApprovalCategoryEntity.java
@@ -1,0 +1,24 @@
+package com.piveguyz.empickbackend.approvals.approval.command.domain.aggregate;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "approval_category")
+@Getter
+@Setter
+@NoArgsConstructor
+public class ApprovalCategoryEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Integer id;
+
+    @Column(name = "approval_category_id", nullable = true)
+    private Integer parentCategoryId;
+
+    @Column(nullable = false)
+    private String name;
+}

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/domain/aggregate/ApprovalCategoryItemEntity.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/domain/aggregate/ApprovalCategoryItemEntity.java
@@ -1,0 +1,25 @@
+package com.piveguyz.empickbackend.approvals.approval.command.domain.aggregate;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "approval_category_item")
+@Getter
+@Setter
+@NoArgsConstructor
+public class ApprovalCategoryItemEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Integer id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "category_id", nullable = false)
+    private int categoryId;
+}

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/domain/aggregate/ApprovalContentEntity.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/domain/aggregate/ApprovalContentEntity.java
@@ -1,0 +1,37 @@
+package com.piveguyz.empickbackend.approvals.approval.command.domain.aggregate;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@ToString
+@Builder
+@Table(name = "approval_content")
+public class ApprovalContentEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private int id;
+
+    @Column(name = "approval_id", nullable = false)
+    private int approvalId;
+
+    @Column(name = "item_id", nullable = false)
+    private int itemId;
+
+    @Lob
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @Builder
+    public ApprovalContentEntity(Integer approvalId, Integer itemId, String content) {
+        this.approvalId = approvalId;
+        this.itemId = itemId;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/domain/aggregate/ApprovalEntity.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/domain/aggregate/ApprovalEntity.java
@@ -1,0 +1,71 @@
+package com.piveguyz.empickbackend.approvals.approval.command.domain.aggregate;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "approval")
+@Getter
+@Setter
+@NoArgsConstructor
+public class ApprovalEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private int id;
+
+    @Column(name = "category_id", nullable = false)
+    private int categoryId;
+
+    @Column(name = "writer_id", nullable = false)
+    private int writerId;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(name = "status", nullable = false)
+    private Integer status = 0; // -1: 반려, 0: 진행중, 1: 완료
+
+    @Column(name = "first_approver_id", nullable = true)
+    private Integer firstApproverId;
+
+    @Column(name = "second_approver_id", nullable = true)
+    private Integer secondApproverId;
+
+    @Column(name = "third_approver_id", nullable = true)
+    private Integer thirdApproverId;
+
+    @Column(name = "fourth_approver_id", nullable = true)
+    private Integer fourthApproverId;
+
+    @Column(name = "first_approved_at", nullable = true)
+    private LocalDateTime firstApprovedAt;
+
+    @Column(name = "second_approved_at", nullable = true)
+    private LocalDateTime secondApprovedAt;
+
+    @Column(name = "third_approved_at", nullable = true)
+    private LocalDateTime thirdApprovedAt;
+
+    @Column(name = "fourth_approved_at", nullable = true)
+    private LocalDateTime fourthApprovedAt;
+
+    @Builder
+    public ApprovalEntity(int categoryId, int writerId,
+                          Integer firstApproverId, Integer secondApproverId,
+                          Integer thirdApproverId, Integer fourthApproverId) {
+        this.categoryId = categoryId;
+        this.writerId = writerId;
+        this.firstApproverId = firstApproverId;
+        this.secondApproverId = secondApproverId;
+        this.thirdApproverId = thirdApproverId;
+        this.fourthApproverId = fourthApproverId;
+        this.status = 0;
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/domain/repository/ApprovalCategoryItemRepository.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/domain/repository/ApprovalCategoryItemRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ApprovalCategoryItemRepository extends JpaRepository<ApprovalCategoryItemEntity, Integer> {
+    boolean existsByIdAndCategoryId(Integer itemId, Integer categoryId);
 }

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/domain/repository/ApprovalCategoryItemRepository.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/domain/repository/ApprovalCategoryItemRepository.java
@@ -1,0 +1,9 @@
+package com.piveguyz.empickbackend.approvals.approval.command.domain.repository;
+
+import com.piveguyz.empickbackend.approvals.approval.command.domain.aggregate.ApprovalCategoryItemEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ApprovalCategoryItemRepository extends JpaRepository<ApprovalCategoryItemEntity, Integer> {
+}

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/domain/repository/ApprovalContentRepository.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/domain/repository/ApprovalContentRepository.java
@@ -1,0 +1,9 @@
+package com.piveguyz.empickbackend.approvals.approval.command.domain.repository;
+
+import com.piveguyz.empickbackend.approvals.approval.command.domain.aggregate.ApprovalContentEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ApprovalContentRepository extends JpaRepository<ApprovalContentEntity, Integer> {
+}

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/domain/repository/ApprovalRepository.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/domain/repository/ApprovalRepository.java
@@ -1,0 +1,9 @@
+package com.piveguyz.empickbackend.approvals.approval.command.domain.repository;
+
+import com.piveguyz.empickbackend.approvals.approval.command.domain.aggregate.ApprovalEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ApprovalRepository extends JpaRepository<ApprovalEntity, Integer> {
+}


### PR DESCRIPTION
### 🪄 PR 타입
- [X] 신규 기능
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] 버그 픽스

### #️⃣ 연관된 이슈
close #이슈번호


### 📝 변경 사항
- 결재 문서 생성
```json
{
  "categoryId": 2,      // 어느 유형의 결재인지
  "writerId": 10,         // 결재 요청 사원 id
  "approvers": [
    {
      "order": 1,           // 결재 라인 순서
      "memberId": 10  // 결재자
    },
    {
      "order": 2,
      "memberId": 1
    }
  ],
  "contents": [
    {
      "itemId": 2,         // 결재 유형별 항목 id
      "content": "2025-06-16"    // 유형에 해당하는 내용
    }
  ]
}
```


----

### 📷 관련 스크린샷
![{52506396-98F6-4648-901D-C759A4E55754}](https://github.com/user-attachments/assets/0c3ac8fd-7f7d-4506-892c-0816f8e8a323)


### 🧪 테스트 계획 또는 완료 사항
- [ ] 결재 문서 생성 : [POST] /api/v1/approvals
