### PR TITLE
[refactor] 실무테스트 문제 선택지 삭제 수정

### DIFF
--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/question/command/application/controller/QuestionOptionCommandController.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/question/command/application/controller/QuestionOptionCommandController.java
@@ -72,11 +72,11 @@ public class QuestionOptionCommandController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "2417", description = "선택지를 찾을 수 없습니다."),
     })
-    @DeleteMapping("/{id}")
-    public ResponseEntity<CustomApiResponse<Integer>> deleteOption(
-            @PathVariable int id) {
-        int deleteId = questionOptionCommandService.deleteQuestionOption(id);
+    @DeleteMapping("/{questionId}")
+    public ResponseEntity<CustomApiResponse<String>> deleteOption(
+            @PathVariable int questionId) {
+        questionOptionCommandService.deleteQuestionOption(questionId);
         return ResponseEntity.status(ResponseCode.SUCCESS.getHttpStatus())
-                .body(CustomApiResponse.of(ResponseCode.SUCCESS, deleteId));
+                .body(CustomApiResponse.of(ResponseCode.SUCCESS, ResponseCode.SUCCESS.getMessage()));
     }
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/question/command/application/service/QuestionOptionCommandService.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/question/command/application/service/QuestionOptionCommandService.java
@@ -10,5 +10,5 @@ public interface QuestionOptionCommandService {
 
     UpdateQuestionOptionCommandDTO updateQuestionOption(int id, @Valid UpdateQuestionOptionCommandDTO updateQuestionOptionCommandDTO);
 
-    Integer deleteQuestionOption(int id);
+    void deleteQuestionOption(int questionId);
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/question/command/application/service/QuestionOptionCommandServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/question/command/application/service/QuestionOptionCommandServiceImpl.java
@@ -8,17 +8,18 @@ import com.piveguyz.empickbackend.employment.jobtests.question.command.applicati
 import com.piveguyz.empickbackend.employment.jobtests.question.command.application.mapper.QuestionOptionMapper;
 import com.piveguyz.empickbackend.employment.jobtests.question.command.domain.aggregate.QuestionOptionEntity;
 import com.piveguyz.empickbackend.employment.jobtests.question.command.domain.repository.QuestionOptionRepository;
+import com.piveguyz.empickbackend.employment.jobtests.question.command.domain.repository.QuestionRepository;
 import org.springframework.stereotype.Service;
-
-import java.util.Optional;
 
 @Service
 public class QuestionOptionCommandServiceImpl implements QuestionOptionCommandService {
 
     private final QuestionOptionRepository questionOptionRepository;
+    private final QuestionRepository questionRepository;
 
-    public QuestionOptionCommandServiceImpl(QuestionOptionRepository questionOptionRepository) {
+    public QuestionOptionCommandServiceImpl(QuestionOptionRepository questionOptionRepository, QuestionRepository questionRepository) {
         this.questionOptionRepository = questionOptionRepository;
+        this.questionRepository = questionRepository;
     }
 
     // 선택지 등록
@@ -55,10 +56,7 @@ public class QuestionOptionCommandServiceImpl implements QuestionOptionCommandSe
 
     // 선택지 삭제
     @Override
-    public Integer deleteQuestionOption(int id) {
-        QuestionOptionEntity option = questionOptionRepository.findById(id)
-                .orElseThrow(() -> new BusinessException(ResponseCode.EMPLOYMENT_QUESTION_OPTION_NOT_FOUND));
-        questionOptionRepository.delete(option);
-        return option.getId();
+    public void deleteQuestionOption(int questionId) {
+        questionOptionRepository.deleteByQuestionId(questionId);
     }
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/question/command/domain/repository/QuestionOptionRepository.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/question/command/domain/repository/QuestionOptionRepository.java
@@ -2,11 +2,20 @@ package com.piveguyz.empickbackend.employment.jobtests.question.command.domain.r
 
 import com.piveguyz.empickbackend.employment.jobtests.question.command.domain.aggregate.QuestionOptionEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
 @Repository
 public interface QuestionOptionRepository extends JpaRepository<QuestionOptionEntity, Integer> {
     int countByQuestionId(int questionId);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM QuestionOptionEntity qo WHERE qo.questionId = :questionId")
+    void deleteByQuestionId(@Param("questionId") Integer questionId);
 }


### PR DESCRIPTION
### 🪄 PR 타입
- [ ] 신규 기능
- [X] 기능 수정
- [ ] 리팩토링
- [ ] 버그 픽스

### #️⃣ 연관된 이슈
close #이슈번호


### 📝 변경 사항
- 실무테스트 문제 선택지 삭제 시 문제 id와 관련된 선택지 모두 삭제

###  💭참고 사항
https://github.com/Pive-Guyz/be14-fin-Empick-FE/pull/107 프론트 PR과 함께 확인하면 테스트를 좀 더 쉽게 하실 수 있습니다.
----


### 📷 관련 스크린샷
![{CE4D13F5-B0E3-4885-8FEC-1A285E602B1C}](https://github.com/user-attachments/assets/809b4087-a38e-4c62-819a-e4705a995eac)


### 🧪 테스트 계획 또는 완료 사항
- [ ] 실무테스트 문제 선택지 삭제 : [DELETE] /api/v1/employment/question-options/{questionId}
