### PR TITLE
[feat] 채용공고별 지원서 조회 기능 구현

### DIFF
--- a/src/main/java/com/piveguyz/empickbackend/employment/recruitment/query/controller/RecruitmentQueryController.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/recruitment/query/controller/RecruitmentQueryController.java
@@ -3,6 +3,8 @@ package com.piveguyz.empickbackend.employment.recruitment.query.controller;
 import com.piveguyz.empickbackend.common.exception.BusinessException;
 import com.piveguyz.empickbackend.common.response.CustomApiResponse;
 import com.piveguyz.empickbackend.common.response.ResponseCode;
+import com.piveguyz.empickbackend.employment.applicant.query.dto.ApplicantQueryDTO;
+import com.piveguyz.empickbackend.employment.applicant.query.dto.ApplicationQueryDTO;
 import com.piveguyz.empickbackend.employment.recruitment.query.dto.RecruitmentQueryConditionDTO;
 import com.piveguyz.empickbackend.employment.recruitment.query.dto.RecruitmentQueryDTO;
 import com.piveguyz.empickbackend.employment.recruitment.query.service.RecruitmentQueryService;
@@ -60,5 +62,15 @@ public class RecruitmentQueryController {
 
 		return ResponseEntity.status(ResponseCode.SUCCESS.getHttpStatus())
 			.body(CustomApiResponse.of(ResponseCode.SUCCESS, dto));
+	}
+
+	@Operation(summary = "채용공고별 지원서 조회", description = "특정 채용공고에 등록된 모든 지원서를 조회합니다.")
+	@GetMapping("/{recruitmentId}/applications")
+	public ResponseEntity<CustomApiResponse<List<ApplicationQueryDTO>>> getApplicationsByRecruitmentId(
+		@PathVariable("recruitmentId") int recruitmentId
+	) {
+		List<ApplicationQueryDTO> result = recruitmentQueryService.findApplicationsByRecruitmentId(recruitmentId);
+		return ResponseEntity.status(ResponseCode.SUCCESS.getHttpStatus())
+			.body(CustomApiResponse.of(ResponseCode.SUCCESS, result));
 	}
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/recruitment/query/mapper/RecruitmentQueryMapper.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/recruitment/query/mapper/RecruitmentQueryMapper.java
@@ -5,6 +5,8 @@ import java.util.List;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
+import com.piveguyz.empickbackend.employment.applicant.query.dto.ApplicantQueryDTO;
+import com.piveguyz.empickbackend.employment.applicant.query.dto.ApplicationQueryDTO;
 import com.piveguyz.empickbackend.employment.recruitment.query.dto.RecruitmentQueryConditionDTO;
 import com.piveguyz.empickbackend.employment.recruitment.query.dto.RecruitmentQueryDTO;
 
@@ -13,4 +15,6 @@ public interface RecruitmentQueryMapper {
 	List<RecruitmentQueryDTO> findRecruitments(@Param("condition") RecruitmentQueryConditionDTO condition);
 
 	RecruitmentQueryDTO findById(@Param("id") int id);
+
+	List<ApplicationQueryDTO> selectApplicationsByRecruitmentId(int recruitmentId);
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/recruitment/query/service/RecruitmentQueryService.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/recruitment/query/service/RecruitmentQueryService.java
@@ -2,6 +2,8 @@ package com.piveguyz.empickbackend.employment.recruitment.query.service;
 
 import java.util.List;
 
+import com.piveguyz.empickbackend.employment.applicant.query.dto.ApplicantQueryDTO;
+import com.piveguyz.empickbackend.employment.applicant.query.dto.ApplicationQueryDTO;
 import com.piveguyz.empickbackend.employment.recruitment.query.dto.RecruitmentQueryConditionDTO;
 import com.piveguyz.empickbackend.employment.recruitment.query.dto.RecruitmentQueryDTO;
 
@@ -9,4 +11,6 @@ public interface RecruitmentQueryService {
 	List<RecruitmentQueryDTO> findRecruitments(RecruitmentQueryConditionDTO condition);
 
 	RecruitmentQueryDTO findById(int recruitmentId);
+
+	List<ApplicationQueryDTO> findApplicationsByRecruitmentId(int recruitmentId);
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/recruitment/query/service/RecruitmentQueryServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/recruitment/query/service/RecruitmentQueryServiceImpl.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Service;
 
 import com.piveguyz.empickbackend.common.exception.BusinessException;
 import com.piveguyz.empickbackend.common.response.ResponseCode;
+import com.piveguyz.empickbackend.employment.applicant.query.dto.ApplicantQueryDTO;
+import com.piveguyz.empickbackend.employment.applicant.query.dto.ApplicationQueryDTO;
 import com.piveguyz.empickbackend.employment.recruitment.query.dto.RecruitmentQueryConditionDTO;
 import com.piveguyz.empickbackend.employment.recruitment.query.dto.RecruitmentQueryDTO;
 import com.piveguyz.empickbackend.employment.recruitment.query.mapper.RecruitmentQueryMapper;
@@ -29,5 +31,10 @@ public class RecruitmentQueryServiceImpl implements RecruitmentQueryService {
 			throw new BusinessException(ResponseCode.EMPLOYMENT_RECRUITMENT_NOT_FOUND);
 		}
 		return result;
+	}
+
+	@Override
+	public List<ApplicationQueryDTO> findApplicationsByRecruitmentId(int recruitmentId) {
+		return recruitmentQueryMapper.selectApplicationsByRecruitmentId(recruitmentId);
 	}
 }

--- a/src/main/resources/mapper/recruitment/RecruitmentQueryMapper.xml
+++ b/src/main/resources/mapper/recruitment/RecruitmentQueryMapper.xml
@@ -26,6 +26,18 @@
         <result column="introduce_template_id" property="introduceTemplateId"/>
         <result column="recruitment_request_id" property="recruitmentRequestId"/>
     </resultMap>
+    <resultMap id="ApplicationResultMap" type="com.piveguyz.empickbackend.employment.applicant.query.dto.ApplicationQueryDTO">
+        <id column="id" property="id"/>
+        <result column="recruitment_id" property="recruitmentId"/>
+        <result column="created_at" property="createdAt"/>
+        <result column="status" property="status"
+                typeHandler="com.piveguyz.empickbackend.common.handler.ApplicationStatusHandler"/>
+        <result column="applicant_id" property="applicantId"/>
+        <result column="introduce_rating_result_id" property="introduceRatingResultId"/>
+        <result column="interview_id" property="interviewId"/>
+        <result column="updated_at" property="updatedAt"/>
+        <result column="updated_by" property="updatedBy"/>
+    </resultMap>
 
     <!-- 채용 공고 목록 조회 -->
     <select id="findRecruitments" resultMap="RecruitmentResultMap">
@@ -97,5 +109,21 @@
                  LEFT JOIN department d ON m.department_id = d.id
         WHERE r.id = #{id}
           AND r.deleted_at IS NULL
+    </select>
+
+    <!-- 채용공고별 지원서 조회 -->
+    <select id="selectApplicationsByRecruitmentId"
+            resultMap="ApplicationResultMap">
+        SELECT
+            a.id,
+            a.recruitment_id,
+            a.created_at,
+            a.status,
+            a.applicant_id,
+            a.introduce_rating_result_id,
+            a.updated_at,
+            a.updated_by
+        FROM application a
+        WHERE a.recruitment_id = #{recruitmentId}
     </select>
 </mapper>


### PR DESCRIPTION
### 🪄 PR 타입
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] 버그 픽스

### 📝 변경 사항
* 채용공고별 지원서 조회

### 🧪 테스트 사항
- [GET] /api/v1/employment/recruitments/{recruitmentId}/applications
![image](https://github.com/user-attachments/assets/a94dce20-731a-4629-8731-c69f87b0b5ff)

