### PR TITLE
[feat] 내가 요청받은 결재문서 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/controller/ApprovalQueryController.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/controller/ApprovalQueryController.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -51,5 +52,15 @@ public class ApprovalQueryController {
 		ResponseCode result = ResponseCode.SUCCESS;
 		return ResponseEntity.status(result.getHttpStatus())
 				.body(CustomApiResponse.of(result, dtoList));
+	}
+
+	// 자신이 결재자인 결재문서 조회
+	@GetMapping("/received")
+	public ResponseEntity<CustomApiResponse<List<ApprovalQueryDTO>>> findReceivedApprovals(
+		@RequestParam("memberId") Integer memberId) {
+
+		List<ApprovalQueryDTO> dtoList = service.findReceivedApprovals(memberId);
+		return ResponseEntity.status(ResponseCode.SUCCESS.getHttpStatus())
+			.body(CustomApiResponse.of(ResponseCode.SUCCESS, dtoList));
 	}
 }

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/dto/ApprovalReceivedQueryDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/dto/ApprovalReceivedQueryDTO.java
@@ -1,0 +1,19 @@
+package com.piveguyz.empickbackend.approvals.approval.query.dto;
+
+import java.time.LocalDateTime;
+
+import com.piveguyz.empickbackend.approvals.approval.command.domain.enums.ApprovalStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ApprovalReceivedQueryDTO {
+	private Integer approvalId;
+	private String categoryName;
+	private String writerName;
+	private LocalDateTime createdAt;
+	private ApprovalStatus status;
+	private Integer myApprovalStep;
+}

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/mapper/ApprovalQueryMapper.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/mapper/ApprovalQueryMapper.java
@@ -15,4 +15,6 @@ public interface ApprovalQueryMapper {
     List<ApprovalQueryDTO> findByCategoryId(Integer categoryId);
 
     List<ApprovalQueryDTO> findByWriterId(Integer writerId);
+
+    List<ApprovalQueryDTO> findReceivedApprovals(Integer memberId);
 }

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/service/ApprovalQueryService.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/service/ApprovalQueryService.java
@@ -13,4 +13,6 @@ public interface ApprovalQueryService {
 	List<ApprovalQueryDTO> findByCategoryId(Integer categoryId);
 
 	List<ApprovalQueryDTO> findByWriterId(Integer writerId);
+
+	List<ApprovalQueryDTO> findReceivedApprovals(Integer memberId);
 }

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/service/ApprovalQueryServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/service/ApprovalQueryServiceImpl.java
@@ -40,4 +40,9 @@ public class ApprovalQueryServiceImpl implements ApprovalQueryService {
 		List<ApprovalQueryDTO> dtoList = mapper.findByWriterId(writerId);
 		return dtoList;
 	}
+
+	@Override
+	public List<ApprovalQueryDTO> findReceivedApprovals(Integer memberId) {
+		return mapper.findReceivedApprovals(memberId);
+	}
 }

--- a/src/main/resources/mapper/approval/ApprovalQueryMapper.xml
+++ b/src/main/resources/mapper/approval/ApprovalQueryMapper.xml
@@ -21,6 +21,16 @@
 
     </resultMap>
 
+    <resultMap id="ApprovalReceivedResultMap" type="ApprovalReceivedQueryDTO">
+        <result column="approval_id" property="approvalId" />
+        <result column="category_name" property="categoryName" />
+        <result column="writer_name" property="writerName" />
+        <result column="created_at" property="createdAt" />
+        <result column="status" property="status"
+                typeHandler="com.piveguyz.empickbackend.common.handler.ApprovalStatusTypeHandler" />
+        <result column="my_approval_step" property="myApprovalStep" />
+    </resultMap>
+
     <select id="findAll" resultMap="ApprovalResultMap">
         SELECT
             id,
@@ -96,5 +106,42 @@
         WHERE writer_id = #{writerId};
     </select>
 
+    <select id="findReceivedApprovals"
+            resultMap="ApprovalReceivedResultMap">
+        SELECT
+            a.id AS approvalId,
+            c.name AS categoryName,
+            m.name AS writerName,
+            a.created_at AS createdAt,
+            a.status,
+
+            -- 내가 몇 번째 결재자인지
+            CASE
+                WHEN a.first_approver_id = #{memberId} THEN 1
+                WHEN a.second_approver_id = #{memberId} THEN 2
+                WHEN a.third_approver_id = #{memberId} THEN 3
+                WHEN a.fourth_approver_id = #{memberId} THEN 4
+                ELSE NULL
+                END AS myApprovalStep,
+
+            -- 내가 결재해야 하는 순서인지 여부
+            CASE
+                WHEN a.first_approver_id = #{memberId} AND a.first_approved_at IS NULL THEN 1
+                WHEN a.second_approver_id = #{memberId} AND a.first_approved_at IS NOT NULL AND a.second_approved_at IS NULL THEN 1
+                WHEN a.third_approver_id = #{memberId} AND a.second_approved_at IS NOT NULL AND a.third_approved_at IS NULL THEN 1
+                WHEN a.fourth_approver_id = #{memberId} AND a.third_approved_at IS NOT NULL AND a.fourth_approved_at IS NULL THEN 1
+                ELSE 0
+                END AS isMyTurn
+
+        FROM approval a
+                 JOIN member m ON a.writer_id = m.id
+                 JOIN approval_category c ON a.category_id = c.id
+        WHERE
+            a.first_approver_id = #{memberId}
+           OR a.second_approver_id = #{memberId}
+           OR a.third_approver_id = #{memberId}
+           OR a.fourth_approver_id = #{memberId}
+        ORDER BY a.created_at DESC
+    </select>
 
 </mapper>


### PR DESCRIPTION
### 🪄 PR 타입
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] 버그 픽스

### 📝 변경 사항
* 로그인한 사용자의 memberId가 결재선에 포함된 모든 문서를 조회

### 🧪 테스트 계획 또는 완료 사항
- [GET] /api/v1/approval/received?memberId=10
![image](https://github.com/user-attachments/assets/ffa55f03-be49-4468-82db-8ac069a7ff6b)
