### PR TITLE
[refactor] 지원서가 존재하는 채용공고 삭제 시 예외 처리

### DIFF
--- a/src/main/java/com/piveguyz/empickbackend/common/response/ResponseCode.java
+++ b/src/main/java/com/piveguyz/empickbackend/common/response/ResponseCode.java
@@ -104,6 +104,7 @@ public enum ResponseCode {
     EMPLOYMENT_RECRUITMENT_NO_MEMBER_ID(false, HttpStatus.BAD_REQUEST, 2041, "작성자 정보가 누락되었습니다."),
     EMPLOYMENT_RECRUITMENT_DUPLICATE_TITLE(false, HttpStatus.CONFLICT, 2042, "같은 제목의 채용 공고가 이미 존재합니다."),
     EMPLOYMENT_RECRUITMENT_INVALID_STATUS_TRANSITION(false, HttpStatus.CONFLICT, 2043, "잘못된 상태 전환입니다. 승인 대기 → 승인 → 게시 → 종료 순으로만 변경 가능합니다."),
+    EMPLOYMENT_RECRUITMENT_HAS_APPLICATIONS(false, HttpStatus.BAD_REQUEST, 2044,"이미 지원자가 존재하는 채용공고는 삭제할 수 없습니다."),
 
     // 4) 지원서 항목
     EMPLOYMENT_APPLICATION_ITEM_CATEGORY_NOT_FOUND(false, HttpStatus.NOT_FOUND, 2050, "지원서 항목 카테고리를 찾을 수 없습니다."),

--- a/src/main/java/com/piveguyz/empickbackend/employment/applicant/command/domain/repository/ApplicationRepository.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/applicant/command/domain/repository/ApplicationRepository.java
@@ -8,4 +8,6 @@ public interface ApplicationRepository extends JpaRepository<ApplicationEntity, 
 
 
     boolean existsByRecruitmentIdAndApplicantId(int recruitmentId, int applicantId);
+
+	boolean existsByRecruitmentId(int id);
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/recruitment/command/application/service/RecruitmentCommandServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/recruitment/command/application/service/RecruitmentCommandServiceImpl.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.piveguyz.empickbackend.common.exception.BusinessException;
 import com.piveguyz.empickbackend.common.response.ResponseCode;
+import com.piveguyz.empickbackend.employment.applicant.command.domain.repository.ApplicationRepository;
 import com.piveguyz.empickbackend.employment.applicationItem.command.application.dto.ApplicationItemCommandDTO;
 import com.piveguyz.empickbackend.employment.applicationItem.command.domain.aggregate.ApplicationItem;
 import com.piveguyz.empickbackend.employment.applicationItem.command.domain.aggregate.ApplicationItemCategory;
@@ -41,6 +42,7 @@ public class RecruitmentCommandServiceImpl implements RecruitmentCommandService 
 	private final RecruitmentProcessRepository recruitmentProcessRepository;
 	private final RecruitmentTemplateCopyCommandService recruitmentTemplateCopyCommandService;
 	private final RecruitmentTemplateRepository recruitmentTemplateRepository;
+	private final ApplicationRepository applicationRepository;
 
 	@Override
 	public void createRecruitment(RecruitmentCommandDTO dto) {
@@ -250,6 +252,12 @@ public class RecruitmentCommandServiceImpl implements RecruitmentCommandService 
 
 		if (recruitment.getDeletedAt() != null) {
 			throw new BusinessException(ResponseCode.EMPLOYMENT_RECRUITMENT_ALREADY_DELETED);
+		}
+
+		// 지원서가 존재하는 채용공고 삭제 불가
+		boolean hasApplications = applicationRepository.existsByRecruitmentId(id);
+		if (hasApplications) {
+			throw new BusinessException(ResponseCode.EMPLOYMENT_RECRUITMENT_HAS_APPLICATIONS);
 		}
 
 		recruitment.setDeletedAt(LocalDateTime.now());


### PR DESCRIPTION
### 🪄 PR 타입
- [ ] 신규 기능
- [ ] 기능 수정
- [x] 리팩토링
- [ ] 버그 픽스

### 📝 변경 사항
* 지원서가 존재하는 채용공고 삭제 시 삭제 불가하도록 예외처리 해두었습니다.

### 📷 관련 스크린샷
![image](https://github.com/user-attachments/assets/e11b5fa8-412f-40fe-95eb-0b9e21d18385)

### 🧪 테스트 계획 또는 완료 사항
- [DELETE] /api/v1/employment/recruitments/{id}
