### PR TITLE
[refactor] 실무테스트 문제 수정/삭제 변경

### DIFF
--- a/src/main/java/com/piveguyz/empickbackend/common/response/ResponseCode.java
+++ b/src/main/java/com/piveguyz/empickbackend/common/response/ResponseCode.java
@@ -167,10 +167,11 @@ public enum ResponseCode {
     EMPLOYMENT_INVALID_QUESTION_TYPE(false, HttpStatus.BAD_REQUEST, 2412, "유효하지 않은 실무테스트 문제 유형입니다."),
     EMPLOYMENT_INVALID_QUESTION(false, HttpStatus.NOT_FOUND, 2413, "요청한 문제를 찾을 수 없습니다."),
     EMPLOYMENT_QUESTION_DELETE_CONFLICT(false, HttpStatus.CONFLICT, 2414, "이 문제는 다른 곳에서 사용 중이므로 삭제할 수 없습니다."),
-
+    EMPLOYMENT_QUESTION_USED_IN_ANSWER(false, HttpStatus.BAD_REQUEST,2415, "해당 문제는 제출된 답변이 있어 삭제할 수 없습니다."),
     EMPLOYMENT_OPTION_COUNT_EXCEEDED(false, HttpStatus.BAD_REQUEST, 2416, "선택지는 최대 5개까지만 등록할 수 있습니다."),
     EMPLOYMENT_QUESTION_OPTION_NOT_FOUND(false, HttpStatus.NOT_FOUND, 2417, "선택지를 찾을 수 없습니다."),
     EMPLOYMENT_QUESTION_OPTION_MAX_NUMBER(false, HttpStatus.BAD_REQUEST, 2418, "선택지는 5번을 초과할 수 없습니다."),
+    EMPLOYMENT_QUESTION_USED_IN_JOBTEST(false, HttpStatus.BAD_REQUEST, 2419, "해당 문제는 실무 테스트에서 사용 중입니다."),
 
     //   2) 실무테스트
     EMPLOYMENT_JOBTEST_DELETE_CONFLICT(false, HttpStatus.CONFLICT, 2420, "이 실무테스트는 다른 곳에서 사용중이므로 수정하거나 삭제할 수 없습니다."),

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/command/domain/repository/AnswerRepository.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/answer/command/domain/repository/AnswerRepository.java
@@ -14,4 +14,6 @@ public interface AnswerRepository extends JpaRepository<AnswerEntity, Integer> {
     Optional<AnswerEntity> findByApplicationJobTestIdAndQuestionId(int applicationJobTestId, int questionId);
 
     List<AnswerEntity> findByApplicationJobTestId(int applicationJobTestId);
+
+    boolean existsByQuestionId(int id);
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/grading/command/domain/repository/GradingCriteriaRepository.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/grading/command/domain/repository/GradingCriteriaRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 @Repository
 public interface GradingCriteriaRepository extends JpaRepository<GradingCriteriaEntity, Integer> {
     List<GradingCriteriaEntity> findByQuestionId(int id);
+
+    void deleteByQuestionId(int id);
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/domain/repository/JobtestQuestionRepository.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/command/domain/repository/JobtestQuestionRepository.java
@@ -17,4 +17,6 @@ public interface JobtestQuestionRepository extends JpaRepository<JobtestQuestion
     Integer findMaxOptionNumberByJobTestId(@Param("jobTestId") int jobTestId);
 
     Optional<JobtestQuestionEntity> findByJobTestIdAndQuestionId(int jobTestId, int questionId);
+
+    boolean existsByQuestionId(int id);
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/question/command/application/dto/UpdateQuestionCommandDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/question/command/application/dto/UpdateQuestionCommandDTO.java
@@ -1,11 +1,14 @@
 package com.piveguyz.empickbackend.employment.jobtests.question.command.application.dto;
 
 import com.piveguyz.empickbackend.employment.jobtests.common.enums.JobtestDifficulty;
+import com.piveguyz.empickbackend.employment.jobtests.grading.command.application.dto.CreateGradingCriteriaCommandDTO;
 import com.piveguyz.empickbackend.employment.jobtests.question.command.domain.aggregate.enums.QuestionType;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+
+import java.util.List;
 
 @Getter
 @ToString
@@ -17,6 +20,9 @@ public class UpdateQuestionCommandDTO {
     private JobtestDifficulty difficulty;
     private String answer;
     private int updatedMemberId;
+
+    private List<CreateQuestionOptionCommandDTO> questionOptions;
+    private List<CreateGradingCriteriaCommandDTO> gradingCriteria;
 
     @Builder
     public UpdateQuestionCommandDTO(String content, String detailContent, QuestionType type,

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/question/command/application/mapper/QuestionOptionMapper.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/question/command/application/mapper/QuestionOptionMapper.java
@@ -3,6 +3,7 @@ package com.piveguyz.empickbackend.employment.jobtests.question.command.applicat
 import com.piveguyz.empickbackend.employment.jobtests.question.command.application.dto.CreateQuestionOptionCommandDTO;
 import com.piveguyz.empickbackend.employment.jobtests.question.command.application.dto.CreateQuestionOptionResponse;
 import com.piveguyz.empickbackend.employment.jobtests.question.command.application.dto.UpdateQuestionOptionCommandDTO;
+import com.piveguyz.empickbackend.employment.jobtests.question.command.domain.aggregate.QuestionEntity;
 import com.piveguyz.empickbackend.employment.jobtests.question.command.domain.aggregate.QuestionOptionEntity;
 
 public class QuestionOptionMapper {

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/question/command/application/service/QuestionCommandServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/question/command/application/service/QuestionCommandServiceImpl.java
@@ -2,8 +2,11 @@ package com.piveguyz.empickbackend.employment.jobtests.question.command.applicat
 
 import com.piveguyz.empickbackend.common.exception.BusinessException;
 import com.piveguyz.empickbackend.common.response.ResponseCode;
+import com.piveguyz.empickbackend.employment.jobtests.answer.command.domain.repository.AnswerRepository;
 import com.piveguyz.empickbackend.employment.jobtests.grading.command.application.mapper.GradingCriteriaMapper;
 import com.piveguyz.empickbackend.employment.jobtests.grading.command.domain.repository.GradingCriteriaRepository;
+import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.domain.repository.JobtestQuestionRepository;
+import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.domain.repository.JobtestRepository;
 import com.piveguyz.empickbackend.employment.jobtests.question.command.application.dto.CreateQuestionCommandDTO;
 import com.piveguyz.empickbackend.employment.jobtests.question.command.application.dto.CreateQuestionOptionCommandDTO;
 import com.piveguyz.empickbackend.employment.jobtests.question.command.application.dto.DeleteQuestionCommandDTO;
@@ -33,6 +36,9 @@ public class QuestionCommandServiceImpl implements QuestionCommandService {
     private final QuestionOptionRepository questionOptionRepository;
     private final GradingCriteriaRepository gradingCriteriaRepository;
     private final MemberRepository memberRepository;
+    private final AnswerRepository answerRepository;
+    private final JobtestRepository jobtestRepository;
+    private final JobtestQuestionRepository jobtestQuestionRepository;
 
 
     // 실무 테스트 문제 등록
@@ -101,6 +107,16 @@ public class QuestionCommandServiceImpl implements QuestionCommandService {
         // 문제 있는지 확인
         QuestionEntity question = questionRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ResponseCode.EMPLOYMENT_INVALID_QUESTION));
+
+        // 답안에서 참조중이라면
+        if(answerRepository.existsByQuestionId(id)) {
+            throw new BusinessException(ResponseCode.EMPLOYMENT_QUESTION_USED_IN_ANSWER);
+        }
+
+        // 실무테스트에서 참조중이라면
+        if(jobtestQuestionRepository.existsByQuestionId(id)) {
+            throw new BusinessException(ResponseCode.EMPLOYMENT_QUESTION_USED_IN_JOBTEST);
+        }
 
         try {
             questionRepository.delete(question);

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/question/command/application/service/QuestionCommandServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/question/command/application/service/QuestionCommandServiceImpl.java
@@ -73,6 +73,16 @@ public class QuestionCommandServiceImpl implements QuestionCommandService {
             throw new BusinessException(ResponseCode.EMPLOYMENT_INVALID_UPDATED_MEMBER);
         }
 
+        // 답안에서 참조중이라면
+        if(answerRepository.existsByQuestionId(id)) {
+            throw new BusinessException(ResponseCode.EMPLOYMENT_QUESTION_USED_IN_ANSWER);
+        }
+
+        // 실무테스트에서 참조중이라면
+        if(jobtestQuestionRepository.existsByQuestionId(id)) {
+            throw new BusinessException(ResponseCode.EMPLOYMENT_QUESTION_USED_IN_JOBTEST);
+        }
+
         question.updateQuestionEntity(updateQuestionCommandDTO);
 
         QuestionEntity updatedEntity = questionRepository.save(question);

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/question/command/application/service/QuestionCommandServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/question/command/application/service/QuestionCommandServiceImpl.java
@@ -2,29 +2,38 @@ package com.piveguyz.empickbackend.employment.jobtests.question.command.applicat
 
 import com.piveguyz.empickbackend.common.exception.BusinessException;
 import com.piveguyz.empickbackend.common.response.ResponseCode;
+import com.piveguyz.empickbackend.employment.jobtests.grading.command.application.mapper.GradingCriteriaMapper;
+import com.piveguyz.empickbackend.employment.jobtests.grading.command.domain.repository.GradingCriteriaRepository;
 import com.piveguyz.empickbackend.employment.jobtests.question.command.application.dto.CreateQuestionCommandDTO;
+import com.piveguyz.empickbackend.employment.jobtests.question.command.application.dto.CreateQuestionOptionCommandDTO;
 import com.piveguyz.empickbackend.employment.jobtests.question.command.application.dto.DeleteQuestionCommandDTO;
 import com.piveguyz.empickbackend.employment.jobtests.question.command.application.dto.UpdateQuestionCommandDTO;
 import com.piveguyz.empickbackend.employment.jobtests.question.command.application.mapper.QuestionMapper;
+import com.piveguyz.empickbackend.employment.jobtests.question.command.application.mapper.QuestionOptionMapper;
 import com.piveguyz.empickbackend.employment.jobtests.question.command.domain.aggregate.QuestionEntity;
+import com.piveguyz.empickbackend.employment.jobtests.question.command.domain.aggregate.QuestionOptionEntity;
+import com.piveguyz.empickbackend.employment.jobtests.question.command.domain.aggregate.enums.QuestionType;
+import com.piveguyz.empickbackend.employment.jobtests.question.command.domain.repository.QuestionOptionRepository;
 import com.piveguyz.empickbackend.employment.jobtests.question.command.domain.repository.QuestionRepository;
 import com.piveguyz.empickbackend.orgstructure.member.command.domain.repository.MemberRepository;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 @Service
+@RequiredArgsConstructor
 public class QuestionCommandServiceImpl implements QuestionCommandService {
 
     private final QuestionRepository questionRepository;
+    private final QuestionOptionRepository questionOptionRepository;
+    private final GradingCriteriaRepository gradingCriteriaRepository;
     private final MemberRepository memberRepository;
 
-    public QuestionCommandServiceImpl(QuestionRepository questionRepository,
-                                      MemberRepository memberRepository) {
-        this.questionRepository = questionRepository;
-        this.memberRepository = memberRepository;
-    }
 
     // 실무 테스트 문제 등록
     @Override
@@ -61,6 +70,27 @@ public class QuestionCommandServiceImpl implements QuestionCommandService {
         question.updateQuestionEntity(updateQuestionCommandDTO);
 
         QuestionEntity updatedEntity = questionRepository.save(question);
+
+        // 4. 선택형 문제라면 기존 선택지 삭제 후 재등록
+        if (question.getType() == QuestionType.MULTIPLE) {
+            // 기존 선택지 삭제
+            questionOptionRepository.deleteByQuestionId(id);
+
+            // 새 선택지 저장
+            List<QuestionOptionEntity> newOptions = new ArrayList<>();
+            List<CreateQuestionOptionCommandDTO> optionDTOs = updateQuestionCommandDTO.getQuestionOptions();
+
+            for (int i = 0; i < optionDTOs.size(); i++) {
+                CreateQuestionOptionCommandDTO dto = optionDTOs.get(i);
+                QuestionOptionEntity entity = QuestionOptionMapper.toEntity(dto, i + 1, id);
+                newOptions.add(entity);
+            }
+
+            questionOptionRepository.saveAll(newOptions);
+        }
+
+        // 5. 🚩TODO : 서술형 문제라면 기존 채점 기준 삭제 후 재등록
+
 
         return QuestionMapper.toUpdateDto(updatedEntity);
     }


### PR DESCRIPTION
### 🪄 PR 타입
- [ ] 신규 기능
- [X] 기능 수정
- [ ] 리팩토링
- [ ] 버그 픽스

### #️⃣ 연관된 이슈
close #이슈번호


### 📝 변경 사항
- 실무테스트 선택형 문제 수정 시 선택지도 수정 가능하게 변경
- 실무테스트 문제 삭제 시 예외 상황 구체적으로 추가(답안이 있을 때, 실무테스트에 할당되어 있을 때)


----

### 📷 관련 스크린샷
- 답안이 있는 경우
![{54DC9B76-10A4-49D5-8791-6AA79E76D6BD}](https://github.com/user-attachments/assets/cc356370-ca7c-491f-8fdb-48b6a39cccf5)

- 실무테스트에서 사용중인 경우
![{E309D04E-4BDA-4D5E-B734-0A3F323A0EEE}](https://github.com/user-attachments/assets/6285b26a-c511-4c0e-9693-75aacecb7222)


### 🧪 테스트 계획 또는 완료 사항
- 프론트의 https://github.com/Pive-Guyz/be14-fin-Empick-FE/pull/135 PR과 함께 확인하시면 빠르게 PR처리와 테스트를 하실 수 있습니다.
