### PR TITLE
[feat] 결재 라인 조회 구현 / [refactor] 결재 요청 수정

### DIFF
--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/application/dto/CreateApprovalCommandDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/application/dto/CreateApprovalCommandDTO.java
@@ -13,16 +13,9 @@ public class CreateApprovalCommandDTO {
 
     private Integer categoryId;
     private Integer writerId;
-    private List<ApproverDTO> approvers; // max 4명까지
     private List<ApprovalContentDTO> contents;
 
     private Integer approvalId;   // 취소 대상 결재 id
-
-    @Getter @Setter
-    public static class ApproverDTO {
-        private Integer order; // 1~4
-        private Integer memberId;
-    }
 
     @Getter @Setter
     public static class ApprovalContentDTO {

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/application/service/ApprovalCommandServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/application/service/ApprovalCommandServiceImpl.java
@@ -68,7 +68,7 @@ public class ApprovalCommandServiceImpl implements ApprovalCommandService {
         for (ApprovalLineEntity line : approvalLineList) {
             // 부서+직책 기준 결재자(멤버) 찾기
             Optional<MemberEntity> approverOpt =
-                    memberRepository.findFirstByDeptIdAndPositionId(deptId, line.getPositionId());
+                    memberRepository.findFirstByDepartmentIdAndPositionId(deptId, line.getPositionId());
             Integer approverId = approverOpt
                     .orElseThrow(() -> new BusinessException(ResponseCode.APPROVAL_APPROVER_NOT_FOUND))
                     .getId();

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/domain/aggregate/ApprovalLineEntity.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/domain/aggregate/ApprovalLineEntity.java
@@ -1,0 +1,27 @@
+package com.piveguyz.empickbackend.approvals.approval.command.domain.aggregate;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "approval_line")
+@Getter
+@Setter
+@NoArgsConstructor
+public class ApprovalLineEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private int id;
+
+    @Column(name = "step_order", nullable = false)
+    private int stepOrder;
+
+    @Column(name = "approval_category_id", nullable = false)
+    private int approvalCategoryId;
+
+    @Column(name = "position_id", nullable = false)
+    private int positionId;
+}

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/domain/repository/ApprovalLineRepository.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/command/domain/repository/ApprovalLineRepository.java
@@ -1,0 +1,12 @@
+package com.piveguyz.empickbackend.approvals.approval.command.domain.repository;
+
+import com.piveguyz.empickbackend.approvals.approval.command.domain.aggregate.ApprovalLineEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ApprovalLineRepository extends JpaRepository<ApprovalLineEntity, Integer> {
+    List<ApprovalLineEntity> findByApprovalCategoryIdOrderByStepOrderAsc(Integer categoryId);
+}

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/controller/ApprovalLineQueryController.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/controller/ApprovalLineQueryController.java
@@ -3,8 +3,11 @@ package com.piveguyz.empickbackend.approvals.approval.query.controller;
 import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalLineQueryDTO;
 import com.piveguyz.empickbackend.approvals.approval.query.mapper.ApprovalQueryMapper;
 import com.piveguyz.empickbackend.approvals.approval.query.service.ApprovalLineService;
+import com.piveguyz.empickbackend.common.response.CustomApiResponse;
+import com.piveguyz.empickbackend.common.response.ResponseCode;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -19,10 +22,11 @@ public class ApprovalLineQueryController {
 
     // 결재라인 미리보기
     @GetMapping("/{categoryId}/lines")
-    public List<ApprovalLineQueryDTO> getApprovalLinePreview(
+    public ResponseEntity<CustomApiResponse<List<ApprovalLineQueryDTO>>> getApprovalLinePreview(
             @PathVariable Integer categoryId,
             @RequestParam Integer writerId
     ) {
-        return approvalLineService.getApprovalLinePreview(categoryId, writerId);
+        return ResponseEntity.status(ResponseCode.SUCCESS.getHttpStatus())
+                .body(CustomApiResponse.of(ResponseCode.SUCCESS, approvalLineService.getApprovalLinePreview(categoryId, writerId)));
     }
 }

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/controller/ApprovalLineQueryController.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/controller/ApprovalLineQueryController.java
@@ -1,0 +1,28 @@
+package com.piveguyz.empickbackend.approvals.approval.query.controller;
+
+import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalLineQueryDTO;
+import com.piveguyz.empickbackend.approvals.approval.query.mapper.ApprovalQueryMapper;
+import com.piveguyz.empickbackend.approvals.approval.query.service.ApprovalLineService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "결재 문서 API", description = "결재 문서 관련 전체 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/approval/categories")
+public class ApprovalLineQueryController {
+
+    private final ApprovalLineService approvalLineService;
+
+    // 결재라인 미리보기
+    @GetMapping("/{categoryId}/lines")
+    public List<ApprovalLineQueryDTO> getApprovalLinePreview(
+            @PathVariable Integer categoryId,
+            @RequestParam Integer writerId
+    ) {
+        return approvalLineService.getApprovalLinePreview(categoryId, writerId);
+    }
+}

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/dto/ApprovalLineQueryDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/dto/ApprovalLineQueryDTO.java
@@ -1,0 +1,15 @@
+package com.piveguyz.empickbackend.approvals.approval.query.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ApprovalLineQueryDTO {
+    private Integer order;
+    private Integer positionId;
+    private String positionName;
+    private Integer memberId;
+    private String memberName;
+    private String departmentName;
+}

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/mapper/ApprovalQueryMapper.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/mapper/ApprovalQueryMapper.java
@@ -1,5 +1,6 @@
 package com.piveguyz.empickbackend.approvals.approval.query.mapper;
 
+import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalLineQueryDTO;
 import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalQueryDTO;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -17,4 +18,6 @@ public interface ApprovalQueryMapper {
     List<ApprovalQueryDTO> findByWriterId(Integer writerId);
 
     List<ApprovalQueryDTO> findReceivedApprovals(Integer memberId);
+
+    List<ApprovalLineQueryDTO> selectApprovalLinePreview(Integer categoryId, Integer writerId);
 }

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/service/ApprovalLineService.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/service/ApprovalLineService.java
@@ -1,0 +1,9 @@
+package com.piveguyz.empickbackend.approvals.approval.query.service;
+
+import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalLineQueryDTO;
+
+import java.util.List;
+
+public interface ApprovalLineService {
+    List<ApprovalLineQueryDTO> getApprovalLinePreview(Integer categoryId, Integer writerId);
+}

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/service/ApprovalLineServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/service/ApprovalLineServiceImpl.java
@@ -1,0 +1,22 @@
+package com.piveguyz.empickbackend.approvals.approval.query.service;
+
+import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalLineQueryDTO;
+import com.piveguyz.empickbackend.approvals.approval.query.mapper.ApprovalQueryMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ApprovalLineServiceImpl implements ApprovalLineService{
+
+    private final ApprovalQueryMapper approvalQueryMapper;
+
+    // 해당 유형에 해당하는 결재 라인 조회
+    @Override
+    public List<ApprovalLineQueryDTO> getApprovalLinePreview(Integer categoryId, Integer writerId) {
+        return approvalQueryMapper.selectApprovalLinePreview(categoryId, writerId);
+    }
+}

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/service/ApprovalLineServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/service/ApprovalLineServiceImpl.java
@@ -2,6 +2,8 @@ package com.piveguyz.empickbackend.approvals.approval.query.service;
 
 import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalLineQueryDTO;
 import com.piveguyz.empickbackend.approvals.approval.query.mapper.ApprovalQueryMapper;
+import com.piveguyz.empickbackend.common.exception.BusinessException;
+import com.piveguyz.empickbackend.common.response.ResponseCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,6 +19,12 @@ public class ApprovalLineServiceImpl implements ApprovalLineService{
     // 해당 유형에 해당하는 결재 라인 조회
     @Override
     public List<ApprovalLineQueryDTO> getApprovalLinePreview(Integer categoryId, Integer writerId) {
-        return approvalQueryMapper.selectApprovalLinePreview(categoryId, writerId);
+        List<ApprovalLineQueryDTO> lines = approvalQueryMapper.selectApprovalLinePreview(categoryId, writerId);
+
+        // 결재 라인 없으면 예외
+        if (lines == null || lines.isEmpty()) {
+            throw new BusinessException(ResponseCode.APPROVAL_LINE_NOT_FOUND);
+        }
+        return lines;
     }
 }

--- a/src/main/java/com/piveguyz/empickbackend/common/response/ResponseCode.java
+++ b/src/main/java/com/piveguyz/empickbackend/common/response/ResponseCode.java
@@ -268,7 +268,7 @@ public enum ResponseCode {
     APPROVAL_NOT_YOUR_TURN(false, HttpStatus.BAD_REQUEST, 3011, "결재 차례가 아닙니다."),
     APPROVAL_REJECT_REASON_REQUIRED(false, HttpStatus.BAD_REQUEST, 3012, "반려 사유가 필요합니다."),
     APPROVAL_ALREADY_PROCESSED(false, HttpStatus.BAD_REQUEST, 3013, "이미 처리된 결재입니다."),
-    APPROVAL_LINE_NOT_FOUND(false, HttpStatus.BAD_REQUEST, 3014, "결재 라인이 존재하지 않습니다."),
+    APPROVAL_LINE_NOT_FOUND(false, HttpStatus.BAD_REQUEST, 3014, "결재 라인이 존재하지 않습니다.\n관리자에게 문의하세요."),
     APPROVAL_CATEGORY_MISSING(false, HttpStatus.BAD_REQUEST, 3015, "결재 유형이 존재하지 않습니다."),
     APPROVAL_WRITER_MISSING(false, HttpStatus.BAD_REQUEST, 3016, "결재 요청자가 존재하지 않습니다.");
 

--- a/src/main/java/com/piveguyz/empickbackend/common/response/ResponseCode.java
+++ b/src/main/java/com/piveguyz/empickbackend/common/response/ResponseCode.java
@@ -266,8 +266,8 @@ public enum ResponseCode {
     APPROVAL_ALREADY_CANCELED(false, HttpStatus.BAD_REQUEST, 3010, "이미 결재 취소된 문서입니다."),
     APPROVAL_NOT_YOUR_TURN(false, HttpStatus.BAD_REQUEST, 3011, "결재 차례가 아닙니다."),
     APPROVAL_REJECT_REASON_REQUIRED(false, HttpStatus.BAD_REQUEST, 3012, "반려 사유가 필요합니다."),
-    APPROVAL_ALREADY_PROCESSED(false, HttpStatus.BAD_REQUEST, 3013, "이미 처리된 결재입니다.");
-
+    APPROVAL_ALREADY_PROCESSED(false, HttpStatus.BAD_REQUEST, 3013, "이미 처리된 결재입니다."),
+    APPROVAL_LINE_NOT_FOUND(false, HttpStatus.BAD_REQUEST, 3014, "결재 라인이 존재하지 않습니다.");
 
 
     private final boolean success;

--- a/src/main/java/com/piveguyz/empickbackend/common/response/ResponseCode.java
+++ b/src/main/java/com/piveguyz/empickbackend/common/response/ResponseCode.java
@@ -267,7 +267,9 @@ public enum ResponseCode {
     APPROVAL_NOT_YOUR_TURN(false, HttpStatus.BAD_REQUEST, 3011, "결재 차례가 아닙니다."),
     APPROVAL_REJECT_REASON_REQUIRED(false, HttpStatus.BAD_REQUEST, 3012, "반려 사유가 필요합니다."),
     APPROVAL_ALREADY_PROCESSED(false, HttpStatus.BAD_REQUEST, 3013, "이미 처리된 결재입니다."),
-    APPROVAL_LINE_NOT_FOUND(false, HttpStatus.BAD_REQUEST, 3014, "결재 라인이 존재하지 않습니다.");
+    APPROVAL_LINE_NOT_FOUND(false, HttpStatus.BAD_REQUEST, 3014, "결재 라인이 존재하지 않습니다."),
+    APPROVAL_CATEGORY_MISSING(false, HttpStatus.BAD_REQUEST, 3015, "결재 유형이 존재하지 않습니다."),
+    APPROVAL_WRITER_MISSING(false, HttpStatus.BAD_REQUEST, 3016, "결재 요청자가 존재하지 않습니다.");
 
 
     private final boolean success;

--- a/src/main/java/com/piveguyz/empickbackend/orgstructure/member/command/domain/repository/MemberRepository.java
+++ b/src/main/java/com/piveguyz/empickbackend/orgstructure/member/command/domain/repository/MemberRepository.java
@@ -10,4 +10,6 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Integer> {
     boolean existsByEmail(String email);
 
     boolean existsByEmployeeNumber(int randomNumber);
+
+    Optional<MemberEntity> findFirstByDeptIdAndPositionId(Integer deptId, Integer positionId);
 }

--- a/src/main/java/com/piveguyz/empickbackend/orgstructure/member/command/domain/repository/MemberRepository.java
+++ b/src/main/java/com/piveguyz/empickbackend/orgstructure/member/command/domain/repository/MemberRepository.java
@@ -11,5 +11,5 @@ public interface MemberRepository extends JpaRepository<MemberEntity, Integer> {
 
     boolean existsByEmployeeNumber(int randomNumber);
 
-    Optional<MemberEntity> findFirstByDeptIdAndPositionId(Integer deptId, Integer positionId);
+    Optional<MemberEntity> findFirstByDepartmentIdAndPositionId(Integer deptId, int positionId);
 }

--- a/src/main/resources/mapper/approval/ApprovalQueryMapper.xml
+++ b/src/main/resources/mapper/approval/ApprovalQueryMapper.xml
@@ -31,6 +31,16 @@
         <result column="my_approval_step" property="myApprovalStep" />
     </resultMap>
 
+<!--    결재 라인 조회-->
+    <resultMap id="ApprovalLinePreviewMap" type="com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalLineQueryDTO">
+        <result property="order"          column="order" />
+        <result property="positionId"     column="positionId" />
+        <result property="positionName"   column="positionName" />
+        <result property="memberId"       column="memberId" />
+        <result property="memberName"     column="memberName" />
+        <result property="departmentName" column="departmentName" />
+    </resultMap>
+
     <select id="findAll" resultMap="ApprovalResultMap">
         SELECT
             id,
@@ -143,5 +153,25 @@
            OR a.fourth_approver_id = #{memberId}
         ORDER BY a.created_at DESC
     </select>
+
+    <!--    결재라인 조회-->
+    <select id="selectApprovalLinePreview"
+            resultMap="ApprovalLinePreviewMap">
+        SELECT al.step_order  AS `order`,
+               al.position_id AS positionId,
+               p.name         AS positionName,
+               m.id           AS memberId,
+               m.name         AS memberName,
+               d.name         AS departmentName
+        FROM approval_line al
+                 JOIN position p ON al.position_id = p.id
+                 JOIN member writer ON writer.id = #{writerId}
+                 LEFT JOIN member m
+                           ON m.department_id = writer.department_id AND m.position_id = al.position_id
+                 LEFT JOIN department d ON d.id = m.department_id
+        WHERE al.approval_category_id = #{categoryId}
+        ORDER BY al.step_order ASC
+    </select>
+
 
 </mapper>


### PR DESCRIPTION
### 🪄 PR 타입
- [X] 신규 기능
- [X] 기능 수정
- [ ] 리팩토링
- [ ] 버그 픽스

### #️⃣ 연관된 이슈
close #이슈번호


### 📝 변경 사항
- 결재 라인 없는 경우 예외 추가
- 결재 문서 작성 페이지에 보여야 할 결재 라인 조회 구현
- 결재 요청 기능에서 결재 라인 선택해 할당했던 기능을 자동으로 할당되게 수정

----

### 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분
-  스웨거로 테스트하는 것보다 프론트의 해당 PR과 함께 테스트하는 것을 추천합니다.

### 📷 스크린샷
 - 결재 라인 없는 경우 나오는 토스트
![image](https://github.com/user-attachments/assets/b5caafc2-aa64-4e18-8249-ac589193f436)

- 결재 라인 자동 할당
![image](https://github.com/user-attachments/assets/68dc4469-311b-4edb-9e4b-a986300e31f5)
