### PR TITLE
[feat] 내가 요청한 결재 문서 목록 조회 및 반환형 수정

### DIFF
--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/controller/ApprovalQueryController.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/controller/ApprovalQueryController.java
@@ -1,6 +1,7 @@
 package com.piveguyz.empickbackend.approvals.approval.query.controller;
 
 import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalQueryDTO;
+import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalReceivedQueryDTO;
 import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalRequestedListQueryDTO;
 import com.piveguyz.empickbackend.approvals.approval.query.service.ApprovalQueryService;
 import com.piveguyz.empickbackend.common.response.CustomApiResponse;
@@ -57,10 +58,10 @@ public class ApprovalQueryController {
 
 	// 자신이 결재자인 결재문서 목록
 	@GetMapping("/received")
-	public ResponseEntity<CustomApiResponse<List<ApprovalQueryDTO>>> findReceivedApprovals(
+	public ResponseEntity<CustomApiResponse<List<ApprovalReceivedQueryDTO>>> findReceivedApprovals(
 		@RequestParam("memberId") Integer memberId) {
 
-		List<ApprovalQueryDTO> dtoList = service.findReceivedApprovals(memberId);
+		List<ApprovalReceivedQueryDTO> dtoList = service.findReceivedApprovals(memberId);
 		return ResponseEntity.status(ResponseCode.SUCCESS.getHttpStatus())
 			.body(CustomApiResponse.of(ResponseCode.SUCCESS, dtoList));
 	}

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/controller/ApprovalQueryController.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/controller/ApprovalQueryController.java
@@ -1,6 +1,7 @@
 package com.piveguyz.empickbackend.approvals.approval.query.controller;
 
 import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalQueryDTO;
+import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalRequestedListQueryDTO;
 import com.piveguyz.empickbackend.approvals.approval.query.service.ApprovalQueryService;
 import com.piveguyz.empickbackend.common.response.CustomApiResponse;
 import com.piveguyz.empickbackend.common.response.ResponseCode;
@@ -18,7 +19,7 @@ import java.util.List;
 @Tag(name = "결재 문서 API", description = "결재 문서 관련 전체 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/approval")
+@RequestMapping("/api/v1/approval/documents")
 public class ApprovalQueryController {
 	private final ApprovalQueryService service;
 
@@ -54,12 +55,22 @@ public class ApprovalQueryController {
 				.body(CustomApiResponse.of(result, dtoList));
 	}
 
-	// 자신이 결재자인 결재문서 조회
+	// 자신이 결재자인 결재문서 목록
 	@GetMapping("/received")
 	public ResponseEntity<CustomApiResponse<List<ApprovalQueryDTO>>> findReceivedApprovals(
 		@RequestParam("memberId") Integer memberId) {
 
 		List<ApprovalQueryDTO> dtoList = service.findReceivedApprovals(memberId);
+		return ResponseEntity.status(ResponseCode.SUCCESS.getHttpStatus())
+			.body(CustomApiResponse.of(ResponseCode.SUCCESS, dtoList));
+	}
+
+	// 내가 요청한 결재문서 목록
+	@GetMapping("/requested")
+	public ResponseEntity<CustomApiResponse<List<ApprovalRequestedListQueryDTO>>> findRequestedApprovals(
+		@RequestParam("memberId") Integer memberId) {
+
+		List<ApprovalRequestedListQueryDTO> dtoList = service.findRequestedApprovals(memberId);
 		return ResponseEntity.status(ResponseCode.SUCCESS.getHttpStatus())
 			.body(CustomApiResponse.of(ResponseCode.SUCCESS, dtoList));
 	}

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/dto/ApprovalRequestedListQueryDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/dto/ApprovalRequestedListQueryDTO.java
@@ -1,0 +1,17 @@
+package com.piveguyz.empickbackend.approvals.approval.query.dto;
+
+import java.time.LocalDateTime;
+
+import com.piveguyz.empickbackend.approvals.approval.command.domain.enums.ApprovalStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ApprovalRequestedListQueryDTO {
+	private Integer approvalId;
+	private String categoryName;
+	private LocalDateTime createdAt;
+	private ApprovalStatus status;
+}

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/mapper/ApprovalQueryMapper.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/mapper/ApprovalQueryMapper.java
@@ -2,6 +2,7 @@ package com.piveguyz.empickbackend.approvals.approval.query.mapper;
 
 import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalLineQueryDTO;
 import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalQueryDTO;
+import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalReceivedQueryDTO;
 import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalRequestedListQueryDTO;
 
 import org.apache.ibatis.annotations.Mapper;
@@ -19,7 +20,7 @@ public interface ApprovalQueryMapper {
 
     List<ApprovalQueryDTO> findByWriterId(Integer writerId);
 
-    List<ApprovalQueryDTO> findReceivedApprovals(Integer memberId);
+    List<ApprovalReceivedQueryDTO> findReceivedApprovals(Integer memberId);
 
     List<ApprovalLineQueryDTO> selectApprovalLinePreview(Integer categoryId, Integer writerId);
 

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/mapper/ApprovalQueryMapper.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/mapper/ApprovalQueryMapper.java
@@ -2,6 +2,8 @@ package com.piveguyz.empickbackend.approvals.approval.query.mapper;
 
 import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalLineQueryDTO;
 import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalQueryDTO;
+import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalRequestedListQueryDTO;
+
 import org.apache.ibatis.annotations.Mapper;
 
 import java.util.List;
@@ -20,4 +22,6 @@ public interface ApprovalQueryMapper {
     List<ApprovalQueryDTO> findReceivedApprovals(Integer memberId);
 
     List<ApprovalLineQueryDTO> selectApprovalLinePreview(Integer categoryId, Integer writerId);
+
+    List<ApprovalRequestedListQueryDTO> findRequestedApprovals(Integer memberId);
 }

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/service/ApprovalQueryService.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/service/ApprovalQueryService.java
@@ -1,6 +1,7 @@
 package com.piveguyz.empickbackend.approvals.approval.query.service;
 
 import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalQueryDTO;
+import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalReceivedQueryDTO;
 import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalRequestedListQueryDTO;
 
 import java.util.List;
@@ -15,7 +16,7 @@ public interface ApprovalQueryService {
 
 	List<ApprovalQueryDTO> findByWriterId(Integer writerId);
 
-	List<ApprovalQueryDTO> findReceivedApprovals(Integer memberId);
+	List<ApprovalReceivedQueryDTO> findReceivedApprovals(Integer memberId);
 
 	List<ApprovalRequestedListQueryDTO> findRequestedApprovals(Integer memberId);
 }

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/service/ApprovalQueryService.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/service/ApprovalQueryService.java
@@ -1,6 +1,7 @@
 package com.piveguyz.empickbackend.approvals.approval.query.service;
 
 import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalQueryDTO;
+import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalRequestedListQueryDTO;
 
 import java.util.List;
 
@@ -15,4 +16,6 @@ public interface ApprovalQueryService {
 	List<ApprovalQueryDTO> findByWriterId(Integer writerId);
 
 	List<ApprovalQueryDTO> findReceivedApprovals(Integer memberId);
+
+	List<ApprovalRequestedListQueryDTO> findRequestedApprovals(Integer memberId);
 }

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/service/ApprovalQueryServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/service/ApprovalQueryServiceImpl.java
@@ -1,6 +1,7 @@
 package com.piveguyz.empickbackend.approvals.approval.query.service;
 
 import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalQueryDTO;
+import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalReceivedQueryDTO;
 import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalRequestedListQueryDTO;
 import com.piveguyz.empickbackend.approvals.approval.query.mapper.ApprovalQueryMapper;
 import com.piveguyz.empickbackend.common.exception.BusinessException;
@@ -43,12 +44,14 @@ public class ApprovalQueryServiceImpl implements ApprovalQueryService {
 	}
 
 	@Override
-	public List<ApprovalQueryDTO> findReceivedApprovals(Integer memberId) {
-		return mapper.findReceivedApprovals(memberId);
+	public List<ApprovalReceivedQueryDTO> findReceivedApprovals(Integer memberId) {
+		List<ApprovalReceivedQueryDTO> dtoList = mapper.findReceivedApprovals(memberId);
+		return dtoList;
 	}
 
 	@Override
 	public List<ApprovalRequestedListQueryDTO> findRequestedApprovals(Integer memberId) {
-		return mapper.findRequestedApprovals(memberId);
+		List<ApprovalRequestedListQueryDTO> dtoList = mapper.findRequestedApprovals(memberId);
+		return dtoList;
 	}
 }

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/service/ApprovalQueryServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/service/ApprovalQueryServiceImpl.java
@@ -1,6 +1,7 @@
 package com.piveguyz.empickbackend.approvals.approval.query.service;
 
 import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalQueryDTO;
+import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalRequestedListQueryDTO;
 import com.piveguyz.empickbackend.approvals.approval.query.mapper.ApprovalQueryMapper;
 import com.piveguyz.empickbackend.common.exception.BusinessException;
 import com.piveguyz.empickbackend.common.response.ResponseCode;
@@ -44,5 +45,10 @@ public class ApprovalQueryServiceImpl implements ApprovalQueryService {
 	@Override
 	public List<ApprovalQueryDTO> findReceivedApprovals(Integer memberId) {
 		return mapper.findReceivedApprovals(memberId);
+	}
+
+	@Override
+	public List<ApprovalRequestedListQueryDTO> findRequestedApprovals(Integer memberId) {
+		return mapper.findRequestedApprovals(memberId);
 	}
 }

--- a/src/main/resources/mapper/approval/ApprovalQueryMapper.xml
+++ b/src/main/resources/mapper/approval/ApprovalQueryMapper.xml
@@ -21,7 +21,7 @@
     </resultMap>
 
 <!--    요청받은 결재 목록 조회-->
-    <resultMap id="ApprovalReceivedResultMap" type="ApprovalReceivedQueryDTO">
+    <resultMap id="ApprovalReceivedResultMap" type="com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalReceivedQueryDTO">
         <result column="approval_id" property="approvalId" />
         <result column="category_name" property="categoryName" />
         <result column="writer_name" property="writerName" />

--- a/src/main/resources/mapper/approval/ApprovalQueryMapper.xml
+++ b/src/main/resources/mapper/approval/ApprovalQueryMapper.xml
@@ -18,9 +18,9 @@
         <result column="second_approved_at" property="secondApprovedAt"/>
         <result column="third_approved_at" property="thirdApprovedAt"/>
         <result column="fourth_approved_at" property="fourthApprovedAt"/>
-
     </resultMap>
 
+<!--    요청받은 결재 목록 조회-->
     <resultMap id="ApprovalReceivedResultMap" type="ApprovalReceivedQueryDTO">
         <result column="approval_id" property="approvalId" />
         <result column="category_name" property="categoryName" />
@@ -29,6 +29,14 @@
         <result column="status" property="status"
                 typeHandler="com.piveguyz.empickbackend.common.handler.ApprovalStatusTypeHandler" />
         <result column="my_approval_step" property="myApprovalStep" />
+    </resultMap>
+
+<!--    요청한 결재 목록 조회-->
+    <resultMap id="ApprovalRequestedListResultMap" type="com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalRequestedListQueryDTO">
+        <id column="approval_id" property="approvalId"/>
+        <result column="category_name" property="categoryName"/>
+        <result column="created_at" property="createdAt"/>
+        <result column="status" property="status" typeHandler="com.piveguyz.empickbackend.common.handler.ApprovalStatusTypeHandler"/>
     </resultMap>
 
 <!--    결재 라인 조회-->
@@ -151,6 +159,19 @@
            OR a.second_approver_id = #{memberId}
            OR a.third_approver_id = #{memberId}
            OR a.fourth_approver_id = #{memberId}
+        ORDER BY a.created_at DESC
+    </select>
+
+<!--    요청한 결재 목록 조회-->
+    <select id="findRequestedApprovals" resultMap="ApprovalRequestedListResultMap">
+        SELECT
+            a.id AS approval_id,
+            ac.name AS category_name,
+            a.created_at,
+            a.status
+        FROM approval a
+                 JOIN approval_category ac ON a.category_id = ac.id
+        WHERE a.writer_id = #{memberId}
         ORDER BY a.created_at DESC
     </select>
 


### PR DESCRIPTION
### 🪄 PR 타입
- [ ] 신규 기능
- [ ] 기능 수정
- [x] 리팩토링
- [ ] 버그 픽스

### 📝 변경 사항
* 내가 요청한 결재문서 목록 조회 화면에 내려줄 정보로 DTO 새로 생성
* 반환형 List로 변경

### 🧪 테스트 사항
- [GET] 내가 요청한 결재문서 목록 조회
/api/v1/approval/documents/requested?memberId=1

- [GET] 요청받은 결재문서 목록 조회
/api/v1/approval/documents/received?memberId=1