### PR TITLE
[feat] 결재문서 상세 조회 기능

### DIFF
--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/controller/ApprovalDetailQueryController.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/controller/ApprovalDetailQueryController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalReceivedDetailQueryDTO;
+import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalRequestedDetailQueryDTO;
 import com.piveguyz.empickbackend.approvals.approval.query.service.ApprovalDetailQueryService;
 import com.piveguyz.empickbackend.approvals.approval.query.service.ApprovalQueryService;
 import com.piveguyz.empickbackend.common.response.CustomApiResponse;
@@ -36,4 +37,12 @@ public class ApprovalDetailQueryController {
 	}
 
 	// 요청한 결재문서 상세조회
+	@GetMapping("/requested/{id}")
+	public ResponseEntity<CustomApiResponse<ApprovalRequestedDetailQueryDTO>> getRequestedApprovalDetail(
+		@PathVariable("id") Integer approvalId
+	) {
+		ApprovalRequestedDetailQueryDTO dto = approvalDetailQueryService.getRequestedApprovalDetail(approvalId);
+		return ResponseEntity.status(ResponseCode.SUCCESS.getHttpStatus())
+			.body(CustomApiResponse.of(ResponseCode.SUCCESS, dto));
+	}
 }

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/controller/ApprovalDetailQueryController.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/controller/ApprovalDetailQueryController.java
@@ -1,0 +1,39 @@
+package com.piveguyz.empickbackend.approvals.approval.query.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalReceivedDetailQueryDTO;
+import com.piveguyz.empickbackend.approvals.approval.query.service.ApprovalDetailQueryService;
+import com.piveguyz.empickbackend.approvals.approval.query.service.ApprovalQueryService;
+import com.piveguyz.empickbackend.common.response.CustomApiResponse;
+import com.piveguyz.empickbackend.common.response.ResponseCode;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "결재 문서 API", description = "결재 문서 관련 전체 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/approval/documents")
+public class ApprovalDetailQueryController {
+
+	private final ApprovalDetailQueryService approvalDetailQueryService;
+
+	// 요청받은 결재문서 상세조회
+	@GetMapping("/received/{id}")
+	public ResponseEntity<CustomApiResponse<ApprovalReceivedDetailQueryDTO>> getReceivedApprovalDetail(
+		@PathVariable("id") Integer approvalId,
+		@RequestParam("memberId") Integer memberId
+	) {
+		ApprovalReceivedDetailQueryDTO dto = approvalDetailQueryService.getReceivedApprovalDetail(approvalId, memberId);
+		return ResponseEntity.status(ResponseCode.SUCCESS.getHttpStatus())
+			.body(CustomApiResponse.of(ResponseCode.SUCCESS, dto));
+	}
+
+	// 요청한 결재문서 상세조회
+}

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/dto/ApprovalContentItemDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/dto/ApprovalContentItemDTO.java
@@ -1,0 +1,14 @@
+package com.piveguyz.empickbackend.approvals.approval.query.dto;
+
+import com.piveguyz.empickbackend.common.enums.InputType;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ApprovalContentItemDTO {
+	private String itemName;
+	private InputType inputType;
+	private String content;
+}

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/dto/ApprovalLineDetailDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/dto/ApprovalLineDetailDTO.java
@@ -1,0 +1,19 @@
+package com.piveguyz.empickbackend.approvals.approval.query.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ApprovalLineDetailDTO {
+	private Integer stepOrder;
+	private Integer memberId;
+	private String memberName;
+	private String positionName;
+	private String departmentName;
+
+	private boolean approved;           // 승인 여부
+	private LocalDateTime approvedAt;   // 승인 일시
+}

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/dto/ApprovalReceivedDetailQueryDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/dto/ApprovalReceivedDetailQueryDTO.java
@@ -1,0 +1,30 @@
+package com.piveguyz.empickbackend.approvals.approval.query.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.piveguyz.empickbackend.approvals.approval.command.domain.enums.ApprovalStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ApprovalReceivedDetailQueryDTO {
+
+	private Integer approvalId;
+	private Integer categoryId;
+	private String categoryName;        // 연차, 반차 등
+	private String writerName;
+	private String writerDepartment;
+	private String writerPosition;
+	private LocalDateTime createdAt;
+	private ApprovalStatus status;      // -2: 취소, -1: 반려, 0: 진행중, 1: 완료
+
+	private List<ApprovalContentItemDTO> items;    // 결재 문서 내용 (항목명 + 내용)
+	private List<ApprovalLineDetailDTO> approvers;  // 결재자들 (결재 순서, 이름, 부서, 직책, 상태)
+
+	private boolean isMyTurn;           // 현재 사용자 차례 여부
+}

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/dto/ApprovalRequestedDetailQueryDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/dto/ApprovalRequestedDetailQueryDTO.java
@@ -14,18 +14,21 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class ApprovalReceivedDetailQueryDTO {
+public class ApprovalRequestedDetailQueryDTO {
 	private Integer approvalId;
 	private Integer categoryId;
-	private String categoryName;        // 연차, 반차 등
+	private String categoryName;
 	private String writerName;
 	private String writerDepartment;
 	private String writerPosition;
 	private LocalDateTime createdAt;
-	private ApprovalStatus status;      // -2: 취소, -1: 반려, 0: 진행중, 1: 완료
+	private ApprovalStatus status;
 
-	private List<ApprovalContentItemDTO> items;    // 결재 문서 내용 (항목명 + 내용)
-	private List<ApprovalLineDetailDTO> approvers;  // 결재자들 (결재 순서, 이름, 부서, 직책, 상태)
+	private List<ApprovalContentItemDTO> items;
+	private List<ApprovalLineDetailDTO> approvers;
 
-	private boolean isMyTurn;           // 현재 사용자 차례 여부
+	private Integer targetApprovalId;            // 취소 대상 문서 ID
+	private String targetCategoryName;           // 취소 대상 문서 유형
+	private String targetWriterName;             // 취소 대상 작성자 이름
+	private ApprovalStatus targetApprovalStatus; // 취소 대상 상태
 }

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/mapper/ApprovalQueryMapper.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/mapper/ApprovalQueryMapper.java
@@ -1,7 +1,9 @@
 package com.piveguyz.empickbackend.approvals.approval.query.mapper;
 
+import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalLineDetailDTO;
 import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalLineQueryDTO;
 import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalQueryDTO;
+import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalReceivedDetailQueryDTO;
 import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalReceivedQueryDTO;
 import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalRequestedListQueryDTO;
 
@@ -25,4 +27,8 @@ public interface ApprovalQueryMapper {
     List<ApprovalLineQueryDTO> selectApprovalLinePreview(Integer categoryId, Integer writerId);
 
     List<ApprovalRequestedListQueryDTO> findRequestedApprovals(Integer memberId);
+
+    ApprovalReceivedDetailQueryDTO findApprovalBasicDetail(Integer approvalId);
+    List<ApprovalLineDetailDTO> findApproverDetails(Integer approvalId);
+    boolean isMyTurn(Integer approvalId, Integer memberId);
 }

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/mapper/ApprovalQueryMapper.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/mapper/ApprovalQueryMapper.java
@@ -5,6 +5,7 @@ import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalLineQuery
 import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalQueryDTO;
 import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalReceivedDetailQueryDTO;
 import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalReceivedQueryDTO;
+import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalRequestedDetailQueryDTO;
 import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalRequestedListQueryDTO;
 
 import org.apache.ibatis.annotations.Mapper;
@@ -31,4 +32,6 @@ public interface ApprovalQueryMapper {
     ApprovalReceivedDetailQueryDTO findApprovalBasicDetail(Integer approvalId);
     List<ApprovalLineDetailDTO> findApproverDetails(Integer approvalId);
     boolean isMyTurn(Integer approvalId, Integer memberId);
+
+    ApprovalRequestedDetailQueryDTO findRequestedApprovalBasicDetail(Integer approvalId);
 }

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/service/ApprovalDetailQueryService.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/service/ApprovalDetailQueryService.java
@@ -1,0 +1,7 @@
+package com.piveguyz.empickbackend.approvals.approval.query.service;
+
+import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalReceivedDetailQueryDTO;
+
+public interface ApprovalDetailQueryService {
+	ApprovalReceivedDetailQueryDTO getReceivedApprovalDetail(Integer approvalId, Integer memberId);
+}

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/service/ApprovalDetailQueryService.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/service/ApprovalDetailQueryService.java
@@ -1,7 +1,10 @@
 package com.piveguyz.empickbackend.approvals.approval.query.service;
 
 import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalReceivedDetailQueryDTO;
+import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalRequestedDetailQueryDTO;
 
 public interface ApprovalDetailQueryService {
 	ApprovalReceivedDetailQueryDTO getReceivedApprovalDetail(Integer approvalId, Integer memberId);
+
+	ApprovalRequestedDetailQueryDTO getRequestedApprovalDetail(Integer approvalId);
 }

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/service/ApprovalDetailQueryServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/service/ApprovalDetailQueryServiceImpl.java
@@ -1,0 +1,64 @@
+package com.piveguyz.empickbackend.approvals.approval.query.service;
+
+import com.piveguyz.empickbackend.approvals.approval.query.dto.*;
+import com.piveguyz.empickbackend.approvals.approval.query.mapper.ApprovalQueryMapper;
+import com.piveguyz.empickbackend.approvals.approvalCategoryItem.query.dto.ApprovalCategoryItemQueryDTO;
+import com.piveguyz.empickbackend.approvals.approvalCategoryItem.query.mapper.ApprovalCategoryItemQueryMapper;
+import com.piveguyz.empickbackend.approvals.approvalContent.query.dto.ApprovalContentQueryDTO;
+import com.piveguyz.empickbackend.approvals.approvalContent.query.mapper.ApprovalContentQueryMapper;
+import com.piveguyz.empickbackend.common.enums.InputType;
+import com.piveguyz.empickbackend.common.exception.BusinessException;
+import com.piveguyz.empickbackend.common.response.ResponseCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ApprovalDetailQueryServiceImpl implements ApprovalDetailQueryService {
+
+	private final ApprovalQueryMapper approvalQueryMapper;
+	private final ApprovalContentQueryMapper contentMapper;
+	private final ApprovalCategoryItemQueryMapper itemMapper;
+
+	@Override
+	public ApprovalReceivedDetailQueryDTO getReceivedApprovalDetail(Integer approvalId, Integer memberId) {
+		ApprovalReceivedDetailQueryDTO basic = approvalQueryMapper.findApprovalBasicDetail(approvalId);
+		if (basic == null) {
+			throw new BusinessException(ResponseCode.NOT_FOUND);
+		}
+
+		List<ApprovalContentQueryDTO> contents = contentMapper.findByApprovalId(approvalId);
+		List<ApprovalCategoryItemQueryDTO> items = itemMapper.findByCategoryId(basic.getCategoryId());
+
+		List<ApprovalContentItemDTO> contentItems = contents.stream().map(c -> {
+			var matched = items.stream()
+				.filter(i -> i.getId().equals(c.getItemId()))
+				.findFirst().orElse(null);
+			return new ApprovalContentItemDTO(
+				matched != null ? matched.getName() : "(알 수 없음)",
+				matched != null ? matched.getInputType() : InputType.TEXT,
+				c.getContent()
+			);
+		}).collect(Collectors.toList());
+
+		List<ApprovalLineDetailDTO> approvers = approvalQueryMapper.findApproverDetails(approvalId);
+		boolean isMyTurn = approvalQueryMapper.isMyTurn(approvalId, memberId);
+
+		return new ApprovalReceivedDetailQueryDTO(
+			basic.getApprovalId(),
+			basic.getCategoryId(),
+			basic.getCategoryName(),
+			basic.getWriterName(),
+			basic.getWriterDepartment(),
+			basic.getWriterPosition(),
+			basic.getCreatedAt(),
+			basic.getStatus(),
+			contentItems,
+			approvers,
+			isMyTurn
+		);
+	}
+}

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/service/ApprovalDetailQueryServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/service/ApprovalDetailQueryServiceImpl.java
@@ -47,18 +47,43 @@ public class ApprovalDetailQueryServiceImpl implements ApprovalDetailQueryServic
 		List<ApprovalLineDetailDTO> approvers = approvalQueryMapper.findApproverDetails(approvalId);
 		boolean isMyTurn = approvalQueryMapper.isMyTurn(approvalId, memberId);
 
-		return new ApprovalReceivedDetailQueryDTO(
-			basic.getApprovalId(),
-			basic.getCategoryId(),
-			basic.getCategoryName(),
-			basic.getWriterName(),
-			basic.getWriterDepartment(),
-			basic.getWriterPosition(),
-			basic.getCreatedAt(),
-			basic.getStatus(),
-			contentItems,
-			approvers,
-			isMyTurn
-		);
+		basic.setItems(contentItems);
+		basic.setApprovers(approvers);
+		basic.setMyTurn(isMyTurn);
+		return basic;
 	}
+
+	@Override
+	public ApprovalRequestedDetailQueryDTO getRequestedApprovalDetail(Integer approvalId) {
+		// 기본 정보
+		ApprovalRequestedDetailQueryDTO basic = approvalQueryMapper.findRequestedApprovalBasicDetail(approvalId);
+		if (basic == null) {
+			throw new BusinessException(ResponseCode.NOT_FOUND);
+		}
+
+		// 결재 문서 내용
+		List<ApprovalContentQueryDTO> contents = contentMapper.findByApprovalId(approvalId);
+		List<ApprovalCategoryItemQueryDTO> items = itemMapper.findByCategoryId(basic.getCategoryId());
+
+		// 내용 매핑 (항목명/입력타입/입력내용)
+		List<ApprovalContentItemDTO> contentItems = contents.stream().map(c -> {
+			var matched = items.stream()
+				.filter(i -> i.getId().equals(c.getItemId()))
+				.findFirst().orElse(null);
+			return new ApprovalContentItemDTO(
+				matched != null ? matched.getName() : "(알 수 없음)",
+				matched != null ? matched.getInputType() : InputType.TEXT,
+				c.getContent()
+			);
+		}).collect(Collectors.toList());
+
+		// 결재자 목록
+		List<ApprovalLineDetailDTO> approvers = approvalQueryMapper.findApproverDetails(approvalId);
+
+		// 결과
+		basic.setItems(contentItems);
+		basic.setApprovers(approvers);
+		return basic;
+	}
+
 }

--- a/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/service/ApprovalQueryService.java
+++ b/src/main/java/com/piveguyz/empickbackend/approvals/approval/query/service/ApprovalQueryService.java
@@ -1,6 +1,7 @@
 package com.piveguyz.empickbackend.approvals.approval.query.service;
 
 import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalQueryDTO;
+import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalReceivedDetailQueryDTO;
 import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalReceivedQueryDTO;
 import com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalRequestedListQueryDTO;
 

--- a/src/main/java/com/piveguyz/empickbackend/common/handler/ApprovalStatusTypeHandler.java
+++ b/src/main/java/com/piveguyz/empickbackend/common/handler/ApprovalStatusTypeHandler.java
@@ -16,18 +16,18 @@ public class ApprovalStatusTypeHandler extends BaseTypeHandler<ApprovalStatus> {
     @Override
     public ApprovalStatus getNullableResult(ResultSet rs, String columnName) throws SQLException {
         int code = rs.getInt(columnName);
-        return ApprovalStatus.fromCode(code);
+        return rs.wasNull() ? null : ApprovalStatus.fromCode(code);
     }
 
     @Override
     public ApprovalStatus getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
         int code = rs.getInt(columnIndex);
-        return ApprovalStatus.fromCode(code);
+        return rs.wasNull() ? null : ApprovalStatus.fromCode(code);
     }
 
     @Override
     public ApprovalStatus getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
         int code = cs.getInt(columnIndex);
-        return ApprovalStatus.fromCode(code);
+        return cs.wasNull() ? null : ApprovalStatus.fromCode(code);
     }
 }

--- a/src/main/resources/mapper/approval/ApprovalDetailQueryMapper.xml
+++ b/src/main/resources/mapper/approval/ApprovalDetailQueryMapper.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.piveguyz.empickbackend.approvals.approval.query.mapper.ApprovalQueryMapper">
+
+    <resultMap id="ApprovalDetailResultMap" type="com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalReceivedDetailQueryDTO">
+        <id property="approvalId" column="approval_id"/>
+        <result property="categoryId" column="category_id"/>
+        <result property="categoryName" column="category_name"/>
+        <result property="writerName" column="writer_name"/>
+        <result property="writerDepartment" column="writer_department"/>
+        <result property="writerPosition" column="writer_position"/>
+        <result property="createdAt" column="created_at"/>
+        <result property="status" column="status" typeHandler="com.piveguyz.empickbackend.common.handler.ApprovalStatusTypeHandler"/>
+    </resultMap>
+
+    <!-- 결재 기본 정보 -->
+    <select id="findApprovalBasicDetail" resultMap="ApprovalDetailResultMap">
+        SELECT
+            a.id AS approval_id,
+            ac.id AS category_id,
+            ac.name AS category_name,
+            m.name AS writer_name,
+            d.name AS writer_department,
+            p.name AS writer_position,
+            a.created_at,
+            a.status
+        FROM approval a
+                 JOIN approval_category ac ON a.category_id = ac.id
+                 JOIN member m ON a.writer_id = m.id
+                 JOIN department d ON m.department_id = d.id
+                 JOIN position p ON m.position_id = p.id
+        WHERE a.id = #{approvalId}
+    </select>
+
+    <!-- 결재자 상세 정보 -->
+    <select id="findApproverDetails" resultType="com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalLineDetailDTO">
+        SELECT 1 AS stepOrder, m1.id AS memberId, m1.name AS memberName, p1.name AS positionName, d1.name AS departmentName,
+               a.first_approved_at IS NOT NULL AS approved, a.first_approved_at AS approvedAt
+        FROM approval a
+                 JOIN member m1 ON a.first_approver_id = m1.id
+                 JOIN department d1 ON m1.department_id = d1.id
+                 JOIN position p1 ON m1.position_id = p1.id
+        WHERE a.id = #{approvalId}
+
+        UNION ALL
+
+        SELECT 2, m2.id, m2.name, p2.name, d2.name,
+               a.second_approved_at IS NOT NULL, a.second_approved_at
+        FROM approval a
+                 JOIN member m2 ON a.second_approver_id = m2.id
+                 JOIN department d2 ON m2.department_id = d2.id
+                 JOIN position p2 ON m2.position_id = p2.id
+        WHERE a.id = #{approvalId} AND a.second_approver_id IS NOT NULL
+
+        UNION ALL
+
+        SELECT 3, m3.id, m3.name, p3.name, d3.name,
+               a.third_approved_at IS NOT NULL, a.third_approved_at
+        FROM approval a
+                 JOIN member m3 ON a.third_approver_id = m3.id
+                 JOIN department d3 ON m3.department_id = d3.id
+                 JOIN position p3 ON m3.position_id = p3.id
+        WHERE a.id = #{approvalId} AND a.third_approver_id IS NOT NULL
+
+        UNION ALL
+
+        SELECT 4, m4.id, m4.name, p4.name, d4.name,
+               a.fourth_approved_at IS NOT NULL, a.fourth_approved_at
+        FROM approval a
+                 JOIN member m4 ON a.fourth_approver_id = m4.id
+                 JOIN department d4 ON m4.department_id = d4.id
+                 JOIN position p4 ON m4.position_id = p4.id
+        WHERE a.id = #{approvalId} AND a.fourth_approver_id IS NOT NULL
+
+        ORDER BY stepOrder
+    </select>
+
+    <!-- 내가 결재할 차례인지 확인 -->
+    <select id="isMyTurn" resultType="boolean">
+        SELECT CASE
+                   WHEN a.first_approver_id = #{memberId} AND a.first_approved_at IS NULL THEN TRUE
+                   WHEN a.second_approver_id = #{memberId} AND a.first_approved_at IS NOT NULL AND a.second_approved_at IS NULL THEN TRUE
+                   WHEN a.third_approver_id = #{memberId} AND a.second_approved_at IS NOT NULL AND a.third_approved_at IS NULL THEN TRUE
+                   WHEN a.fourth_approver_id = #{memberId} AND a.third_approved_at IS NOT NULL AND a.fourth_approved_at IS NULL THEN TRUE
+                   ELSE FALSE
+                   END
+        FROM approval a
+        WHERE a.id = #{approvalId}
+    </select>
+
+</mapper>

--- a/src/main/resources/mapper/approval/ApprovalDetailQueryMapper.xml
+++ b/src/main/resources/mapper/approval/ApprovalDetailQueryMapper.xml
@@ -5,6 +5,7 @@
 
 <mapper namespace="com.piveguyz.empickbackend.approvals.approval.query.mapper.ApprovalQueryMapper">
 
+    <!-- 요청받은 결재문서 상세 조회용 -->
     <resultMap id="ApprovalDetailResultMap" type="com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalReceivedDetailQueryDTO">
         <id property="approvalId" column="approval_id"/>
         <result property="categoryId" column="category_id"/>
@@ -16,6 +17,25 @@
         <result property="status" column="status" typeHandler="com.piveguyz.empickbackend.common.handler.ApprovalStatusTypeHandler"/>
     </resultMap>
 
+    <!-- 요청한 결재문서 상세 조회용 -->
+    <resultMap id="ApprovalRequestedDetailMap" type="com.piveguyz.empickbackend.approvals.approval.query.dto.ApprovalRequestedDetailQueryDTO">
+        <id property="approvalId" column="approval_id"/>
+        <result property="categoryId" column="category_id"/>
+        <result property="categoryName" column="category_name"/>
+        <result property="writerName" column="writer_name"/>
+        <result property="writerDepartment" column="writer_department"/>
+        <result property="writerPosition" column="writer_position"/>
+        <result property="createdAt" column="created_at"/>
+        <result property="status" column="status" typeHandler="com.piveguyz.empickbackend.common.handler.ApprovalStatusTypeHandler"/>
+
+        <!-- 취소 대상 문서 정보 -->
+        <result property="targetApprovalId" column="target_approval_id"/>
+        <result property="targetCategoryName" column="target_category_name"/>
+        <result property="targetWriterName" column="target_writer_name"/>
+        <result property="targetApprovalStatus" column="target_status" typeHandler="com.piveguyz.empickbackend.common.handler.ApprovalStatusTypeHandler"/>
+    </resultMap>
+
+    <!-- 요청받은 결재문서 상세 조회 -->
     <!-- 결재 기본 정보 -->
     <select id="findApprovalBasicDetail" resultMap="ApprovalDetailResultMap">
         SELECT
@@ -91,4 +111,32 @@
         WHERE a.id = #{approvalId}
     </select>
 
+    <!-- 내가 요청한 결재문서 기본 정보 + 취소 대상 정보까지 조회 -->
+    <select id="findRequestedApprovalBasicDetail" resultMap="ApprovalRequestedDetailMap">
+        SELECT
+            a.id AS approval_id,
+            ac.id AS category_id,
+            ac.name AS category_name,
+            m.name AS writer_name,
+            d.name AS writer_department,
+            p.name AS writer_position,
+            a.created_at,
+            a.status,
+
+        <!-- 취소 대상 문서 정보 -->
+            a.approval_id AS target_approval_id,
+            CASE WHEN a.approval_id IS NOT NULL THEN ac2.name ELSE NULL END AS target_category_name,
+            CASE WHEN a.approval_id IS NOT NULL THEN m2.name ELSE NULL END AS target_writer_name,
+            CASE WHEN a.approval_id IS NOT NULL THEN a2.status ELSE NULL END AS target_status
+
+        FROM approval a
+                 JOIN approval_category ac ON a.category_id = ac.id
+                 JOIN member m ON a.writer_id = m.id
+                 JOIN department d ON m.department_id = d.id
+                 JOIN position p ON m.position_id = p.id
+                 LEFT JOIN approval a2 ON a.approval_id = a2.id
+                 LEFT JOIN approval_category ac2 ON a2.category_id = ac2.id
+                 LEFT JOIN member m2 ON a2.writer_id = m2.id
+        WHERE a.id = #{approvalId}
+    </select>
 </mapper>


### PR DESCRIPTION
### 🪄 PR 타입
- [x] 신규 기능
- [x] 기능 수정
- [ ] 리팩토링
- [ ] 버그 픽스

### 📝 변경 사항
* 결재문서 상세 조회 시 필요 내용 모두 표시되도록 수정

### 💬 리뷰 요구사항
* 프론트 feature/hm/approval_detail 과 함께 리뷰 부탁드립니다!

### 🧪 테스트 계획 또는 완료 사항
- [GET] 요청받은 결재문서 상세 조회
/api/v1/approval/documents/received/1?memberId=1
![image](https://github.com/user-attachments/assets/24ec211b-24ac-4261-8bd1-9526240e42be)

- [GET] 요청한 결재문서 상세 조회
/api/v1/approval/documents/requested/4
![image](https://github.com/user-attachments/assets/3f2b0521-1064-4db9-85d3-bdc083ec6e47)

