### PR TITLE
[refactor] 지원서 관련 실무테스트 정보 연동

### DIFF
--- a/src/main/java/com/piveguyz/empickbackend/employment/applicant/query/dto/ApplicantFullInfoDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/applicant/query/dto/ApplicantFullInfoDTO.java
@@ -60,4 +60,8 @@ public class ApplicantFullInfoDTO {
     // 수정한 사원의 memberId (nullable, 시스템 처리일 수도 있음)
     private Integer updatedBy;
 
+    // 실무테스트 할당 관련
+    private Integer applicationJobtestId;
+    private String applicationJobtestTitle;
+
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/applicant/query/dto/ApplicationQueryDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/applicant/query/dto/ApplicationQueryDTO.java
@@ -1,6 +1,7 @@
 package com.piveguyz.empickbackend.employment.applicant.query.dto;
 
 import com.piveguyz.empickbackend.employment.applicant.command.domain.aggregate.ApplicationStatus;
+import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.domain.aggregate.enums.JobtestStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,4 +25,8 @@ public class ApplicationQueryDTO {
     private LocalDateTime updatedAt; // DATETIME 타입은 LocalDateTime이 적절
     private int updatedBy; // 수정자 member_id
 
+    // 실무테스트 정보 조회
+    private Integer applicationJobtestId;
+    private Integer jobtestGradingScore;
+    private JobtestStatus jobtestGradingStatus;
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/query/controller/ApplicationJobtestQueryController.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/query/controller/ApplicationJobtestQueryController.java
@@ -2,15 +2,14 @@ package com.piveguyz.empickbackend.employment.jobtests.jobtest.query.controller;
 
 import com.piveguyz.empickbackend.common.response.CustomApiResponse;
 import com.piveguyz.empickbackend.common.response.ResponseCode;
+import com.piveguyz.empickbackend.employment.jobtests.jobtest.query.dto.ApplicationJobtestAnswerPageDTO;
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.query.dto.ApplicationJobtestQueryDTO;
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.query.dto.ApplicationJobtestRequestDTO;
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.query.dto.ApplicationJobtestResponseDTO;
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.query.service.ApplicationJobtestQueryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.apache.coyote.Response;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -38,6 +37,16 @@ public class ApplicationJobtestQueryController {
                 .body(CustomApiResponse.of(ResponseCode.SUCCESS, applicationJobtestList));
     }
 
+
+    @GetMapping("/{id}")
+    public ResponseEntity<CustomApiResponse<ApplicationJobtestAnswerPageDTO>> getApplicationJobtest(
+            @PathVariable int id
+    ) {
+        ApplicationJobtestAnswerPageDTO applicationJobtestQueryDTO = applicationJobtestQueryService.getApplicationJobtest(id);
+        return ResponseEntity.status(ResponseCode.SUCCESS.getHttpStatus())
+                .body(CustomApiResponse.of(ResponseCode.SUCCESS, applicationJobtestQueryDTO));
+    }
+
     // 특정 지원서에게 할당된 실무테스트 조회
     @Operation(
             summary = "특정 지원서에게 할당된 실무테스트 조회",
@@ -46,7 +55,7 @@ public class ApplicationJobtestQueryController {
                     """
     )
     @GetMapping("/application/{applicationId}")
-    public ResponseEntity<CustomApiResponse<ApplicationJobtestResponseDTO>> getApplicationJobtest(
+    public ResponseEntity<CustomApiResponse<ApplicationJobtestResponseDTO>> getApplicationJobtestByApplicationId(
             @PathVariable int applicationId
     ) {
         ApplicationJobtestResponseDTO dto = applicationJobtestQueryService.getApplicationJobtestByApplicationId(applicationId);

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/query/dto/ApplicationJobtestAnswerPageDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/query/dto/ApplicationJobtestAnswerPageDTO.java
@@ -1,0 +1,18 @@
+package com.piveguyz.empickbackend.employment.jobtests.jobtest.query.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class ApplicationJobtestAnswerPageDTO {
+    private int applicationJobTestId;
+    private String applicantName;
+    private String recruitmentTitle;
+    private Integer applicantId;
+    private Integer applicationId;
+    private String jobtestTitle;
+    private LocalDateTime submittedAt;
+}

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/query/mapper/ApplicationJobtestMapper.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/query/mapper/ApplicationJobtestMapper.java
@@ -1,5 +1,6 @@
 package com.piveguyz.empickbackend.employment.jobtests.jobtest.query.mapper;
 
+import com.piveguyz.empickbackend.employment.jobtests.jobtest.query.dto.ApplicationJobtestAnswerPageDTO;
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.query.dto.ApplicationJobtestQueryDTO;
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.query.dto.ApplicationJobtestResponseDTO;
 import org.apache.ibatis.annotations.Mapper;
@@ -19,4 +20,6 @@ public interface ApplicationJobtestMapper {
     Date selectSubmittedAtById(@Param("applicationJobtestId") int applicationJobtestId);
 
     ApplicationJobtestResponseDTO selectByApplicationId(@Param("applicationId") int applicationId);
+
+    ApplicationJobtestAnswerPageDTO selectById(@Param("id") int id);
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/query/service/ApplicationJobtestQueryService.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/query/service/ApplicationJobtestQueryService.java
@@ -1,6 +1,7 @@
 package com.piveguyz.empickbackend.employment.jobtests.jobtest.query.service;
 
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.application.dto.JobtestEntryRequestDTO;
+import com.piveguyz.empickbackend.employment.jobtests.jobtest.query.dto.ApplicationJobtestAnswerPageDTO;
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.query.dto.ApplicationJobtestQueryDTO;
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.query.dto.ApplicationJobtestRequestDTO;
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.query.dto.ApplicationJobtestResponseDTO;
@@ -16,4 +17,6 @@ public interface ApplicationJobtestQueryService {
     void checkSubmittedAt(int applicationJobtestId);
 
     ApplicationJobtestResponseDTO getApplicationJobtestByApplicationId(int applicationId);
+
+    ApplicationJobtestAnswerPageDTO getApplicationJobtest(int id);
 }

--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/query/service/ApplicationJobtestQueryServiceImpl.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/query/service/ApplicationJobtestQueryServiceImpl.java
@@ -3,6 +3,7 @@ package com.piveguyz.empickbackend.employment.jobtests.jobtest.query.service;
 import com.piveguyz.empickbackend.common.exception.BusinessException;
 import com.piveguyz.empickbackend.common.response.ResponseCode;
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.command.application.dto.JobtestEntryRequestDTO;
+import com.piveguyz.empickbackend.employment.jobtests.jobtest.query.dto.ApplicationJobtestAnswerPageDTO;
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.query.dto.ApplicationJobtestRequestDTO;
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.query.dto.ApplicationJobtestResponseDTO;
 import com.piveguyz.empickbackend.employment.jobtests.jobtest.query.mapper.ApplicationJobtestMapper;
@@ -45,6 +46,11 @@ public class ApplicationJobtestQueryServiceImpl implements ApplicationJobtestQue
     @Override
     public ApplicationJobtestResponseDTO getApplicationJobtestByApplicationId(int applicationId) {
         return applicationJobtestMapper.selectByApplicationId(applicationId);
+    }
+
+    @Override
+    public ApplicationJobtestAnswerPageDTO getApplicationJobtest(int id) {
+        return applicationJobtestMapper.selectById(id);
     }
 
 }

--- a/src/main/resources/mapper/applicant/applicantMapper.xml
+++ b/src/main/resources/mapper/applicant/applicantMapper.xml
@@ -34,6 +34,8 @@
         <result property="status" column="status"/>
         <result property="updatedAt" column="updated_at"/>
         <result property="updatedBy" column="updated_by"/>
+        <result property="applicationJobtestId" column="application_jobtest_id"/>
+        <result property="applicationJobtestTitle" column="application_jobtest_title"/>
     </resultMap>
 
     <select id="findAllApplicantFullInfo" resultMap="ApplicantFullInfoResultMap">
@@ -54,12 +56,17 @@
         j.id as job_id,
         j.name as job_name,
         ap.updated_at,
-        ap.updated_by
+        ap.updated_by,
+        ajt.id AS application_jobtest_id,
+        jt.title AS application_jobtest_title
+
         FROM applicant AS a
         LEFT JOIN application ap ON a.id = ap.applicant_id
         LEFT JOIN recruitment r ON ap.recruitment_id = r.id
         LEFT JOIN recruitment_request rq ON rq.id = r.recruitment_request_id
         LEFT JOIN job j ON j.id = rq.job_id
+        LEFT JOIN application_job_test ajt ON ajt.application_id = ap.id
+        LEFT JOIN job_test jt ON ajt.job_test_id = jt.id
     </select>
 
     <select id="findAllApplicant" resultMap="ApplicantResultMap">

--- a/src/main/resources/mapper/applicant/applicationMapper.xml
+++ b/src/main/resources/mapper/applicant/applicationMapper.xml
@@ -14,6 +14,10 @@
         <result property="interviewId" column="interview_id"/>
         <result property="updatedAt" column="updated_at"/>
         <result property="updatedBy" column="updated_by"/>
+
+        <result property="applicationJobtestId" column="ajt_id"/>
+        <result property="jobtestGradingScore" column="ajt_score"/>
+        <result property="jobtestGradingStatus" column="ajt_grading_status" typeHandler="com.piveguyz.empickbackend.common.handler.JobtestStatusHandler"/>
     </resultMap>
 
     <select id="findAllApplication" resultMap="ApplicationResultMap">
@@ -42,12 +46,16 @@
             a.applicant_id,
             a.introduce_rating_result_id,
             a.updated_at,
-            a.updated_by
+            a.updated_by,
+            ajt.id AS ajt_id,
+            ajt.grading_total_score AS ajt_score,
+            ajt.grading_status AS ajt_grading_status
         FROM application a
                  LEFT JOIN recruitment r ON a.recruitment_id = r.id
                  LEFT JOIN applicant ap ON a.applicant_id = ap.id
                  LEFT JOIN introduce_rating_result irr ON a.introduce_rating_result_id = irr.id
                  LEFT JOIN member m ON a.updated_by = m.id
+                LEFT JOIN application_job_test ajt ON ajt.application_id = a.id
         WHERE a.id = #{id}
     </select>
 

--- a/src/main/resources/mapper/jobtest/ApplicationJobtestMapper.xml
+++ b/src/main/resources/mapper/jobtest/ApplicationJobtestMapper.xml
@@ -76,5 +76,30 @@
     </select>
 
 
+    <resultMap id="ApplicationJobTestMap"
+               type="com.piveguyz.empickbackend.employment.jobtests.jobtest.query.dto.ApplicationJobtestAnswerPageDTO">
+        <result column="application_job_test_id" property="applicationJobTestId"/>
+        <result column="applicant_name" property="applicantName"/>
+        <result column="recruitment_title" property="recruitmentTitle"/>
+        <result column="applicant_id" property="applicantId"/>
+        <result column="application_id" property="applicationId"/>
+        <result column="job_test_title" property="jobtestTitle"/>
+        <result column="submitted_at" property="submittedAt"/>
+    </resultMap>
 
+    <select id="selectById" resultMap="ApplicationJobTestMap">
+        SELECT ajt.id   AS application_job_test_id,
+               a.id     AS application_id,
+               a.applicant_id,
+               ap.name  AS applicant_name,
+               r.title  AS recruitment_title,
+               jt.title AS job_test_title,
+               ajt.submitted_at
+        FROM application_job_test ajt
+                 LEFT JOIN application a ON ajt.application_id = a.id
+                 LEFT JOIN applicant ap ON a.applicant_id = ap.id
+                 LEFT JOIN recruitment r ON a.recruitment_id = r.id
+                 LEFT JOIN job_test jt ON ajt.job_test_id = jt.id
+        WHERE ajt.id = #{id}
+    </select>
 </mapper>


### PR DESCRIPTION
### 🪄 PR 타입
- [ ] 신규 기능
- [X] 기능 수정
- [X] 리팩토링
- [X] 버그 픽스

### #️⃣ 연관된 이슈
close #이슈번호


### 📝 변경 사항
- 지원서에 실무테스트 점수, 상태 연동
- 지원서에서 실무테스트 바로가기 눌렀을 때 실무테스트 정보 없어서 나던 오류 해결

###  💬참고 사항
- 해당 PR과 함께 확인해주세요~
https://github.com/Pive-Guyz/be14-fin-Empick-FE/pull/186

----

### 📷 관련 스크린샷
- 지원서 상세보기 페이지
![image](https://github.com/user-attachments/assets/d1b503cb-d355-4593-944a-967c803ec58c)
![image](https://github.com/user-attachments/assets/ccda9cd6-28f2-482d-8669-91085ad0a4f6)

- 지원서 바로가기 눌렀을 때
![image](https://github.com/user-attachments/assets/9d15f201-987d-4278-8e61-b7c7e12702a9)

### 🧪 테스트 계획 또는 완료 사항
- [ ] [지원서 상세보기 페이지](http://localhost:8080/employment/applications/1?applicantId=1&applicationId=1&name=%EC%84%9C%EB%AF%BC%EC%A2%85&phone=010-2643-7581&email=tjalswhd1@naver.com&profileUrl=https://picsum.photos/seed/app1/200&birth=1997-02-26&address=%EC%84%9C%EC%9A%B8%EC%8B%9C+%EC%A4%91%EB%9E%91%EA%B5%AC+%EB%A9%B4%EB%AA%A9%EB%8F%99&recruitmentId=1&introduceRatingResultId&jobId&jobName&createdAt=2025-06-23T09:32:05&status=PASSED_INTERVIEW&updatedAt=2025-06-24T17:34:50&updatedBy&from=/employment/applicant)
- [ ] [답안 바로가기 페이지](http://localhost:8080/employment/jobtest-answers/8)
