### PR TITLE
[refactor] 시험 정보에 시작 시간 포함

### DIFF
--- a/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/query/dto/JobtestExamQueryDTO.java
+++ b/src/main/java/com/piveguyz/empickbackend/employment/jobtests/jobtest/query/dto/JobtestExamQueryDTO.java
@@ -3,6 +3,7 @@ package com.piveguyz.empickbackend.employment.jobtests.jobtest.query.dto;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter @Setter
@@ -10,6 +11,7 @@ public class JobtestExamQueryDTO {
     private Integer jobtestId;
     private int applicationJobTestId;
     private String title;
+    private LocalDateTime startedAt;
     private Integer testTime;
     private List<JobtestExamQuestionSummaryDTO> questions;
 }

--- a/src/main/resources/mapper/jobtest/JobtestMapper.xml
+++ b/src/main/resources/mapper/jobtest/JobtestMapper.xml
@@ -187,6 +187,7 @@
         <result property="applicationJobTestId" column="application_job_test_id"/>
         <result property="title" column="title"/>
         <result property="testTime" column="test_time"/>
+        <result property="startedAt" column="started_at"/>
         <collection property="questions"
                     ofType="com.piveguyz.empickbackend.employment.jobtests.jobtest.query.dto.JobtestExamQuestionSummaryDTO">
             <id property="questionId" column="question_id"/>
@@ -211,6 +212,7 @@
             ajt.id    AS application_job_test_id,
             jt.title,
             jt.test_time,
+            jt.started_at,
             jq.question_id,
             q.type,
             q.content AS question_title,


### PR DESCRIPTION
### 🪄 PR 타입
- [ ] 신규 기능
- [ ] 기능 수정
- [X] 리팩토링
- [ ] 버그 픽스

### #️⃣ 연관된 이슈
close #이슈번호


### 📝 변경 사항
- 시험 정보 전달 DTO에 시험 시작 시간 추가

----

### 💬 리뷰 요구사항 (선택)
> 리뷰어가 특별히 봐주었으면 하는 부분
프론트의 https://github.com/Pive-Guyz/be14-fin-Empick-FE/pull/198 PR과 함께 확인 부탁드립니다!